### PR TITLE
Fix wrong numbering and missing index record for the REST API proposal

### DIFF
--- a/018-rest-admin-api.md
+++ b/018-rest-admin-api.md
@@ -60,7 +60,7 @@ The strimzi-ui project is affected (as outline in the Proposal). Other projects 
 
 ## Compatibility
 
-There are no compatability issues, as the API is still under development.
+There are no compatibility issues, as the API is still under development.
 
 ## Rejected alternatives
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository list of proposals for the Strimzi project. A template for new pr
 
 |  #  | Title                                                                 |
 | :-: |:----------------------------------------------------------------------|
+| 18  | [Use the admin-server REST API in strimzi-ui](./018-rest-admin-api.md) |
 | 17  | [Proxy-Based Kafka Per-Topic Encryption](./017-kafka-topic-encryption.md) |
 | 16  | [Modularizing Strimzi UI](./016-modularizing-strimzi-ui.md) |
 | 15  | [Kafka Connect build](./015-kafka-connect-build.md) |


### PR DESCRIPTION
When the REST API proposal was merged, it was not properly numbered and it was not added to the index in the README.md file. This PR tries to fix it. It also fixes typo in the proposal.