### PR TITLE
Fix link to the service Binding proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository list of proposals for the Strimzi project. A template for new pr
 
 |  #  | Title                                                                 |
 | :-: |:----------------------------------------------------------------------|
-| 33  | [Service Binding](./031-service-binding.md) |
+| 33  | [Service Binding](./033-service-binding.md) |
 | 32  | [Custom Authentication in Kafka Brokers ](./032-custom_authentication_in_kafka_brokers.md) |
 | 31  | [StatefulSet Removal](./031-statefulset-removal.md) |
 | 30  | [EnvVar Configuration Provider for Apache Kafka](./030-env-var-config-provider.md) |


### PR DESCRIPTION
This PR fixes the incorrect link for the Service Binding proposal which has wrong number in the filename.