### PR TITLE
KRaft mode proposal

### DIFF
--- a/036-kraft-mode.md
+++ b/036-kraft-mode.md
@@ -1,0 +1,103 @@
+# KRaft support: ZooKeeper-less Kafka
+
+## Motivation
+
+The Apache Kafka project is working on removing its dependency on ZooKeeper.
+Because of the complexity of this task, the work is in progress already for more than one year.
+It was stared with the [Kafka Improvement Proposal 500 (KIP-500)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-500%3A+Replace+ZooKeeper+with+a+Self-Managed+Metadata+Quorum) and will continue for at least six to twelve months until all work is done and it is production-ready.
+Step by step, it removes the different dependencies on ZooKeeper.
+From the smaller things such as CLI tools or management APIs up to the complicated tasks such as quorum management and metadata management.
+It is based on _Apache Kafka Raft_ consensus protocol, which is also called _KRaft_.
+This is what gives the name to this proposal as well as to the feature gate discussed later.
+
+Strimzi aims to support the ZooKeeper-less Kafka and the KRaft protocol.
+Since the announcement of the KIP-500, we are making sure that Strimzi is as ready as possible for when the KRaft mode becomes production-ready.
+This includes for example adopting the new APIs based on Kafka instead of ZooKeeper in components such as User Operator or Cruise Control.
+But right now, you cannot really use Strimzi to run Kafka with the KRaft mode enabled.
+That makes it hard to continue working on some of the additional tasks needed to have Strimzi production-ready with KRaft in the future.
+For example the work on the readiness / liveness probes, Topic Operator improvements, upgrades etc.
+All of these tasks will be easier to work on with Strimzi supporting the KRaft mode out-of-the-box.
+
+## Proposal
+
+This proposal suggests to add provisional support for the KRaft mode.
+It will be disabled by default and will be protected by a new feature gate.
+When the feature gate is enabled, it will use the KRaft mode to deploy the Kafka cluster.
+It will simplify development and testing of new Strimzi features in the KRaft mode.
+And it would also allow to help with testing of the KRaft mode it self and raise any issues in the Apache Kafka project.
+
+The KRaft support proposed here is called provisional, because the API in the Kafka CR for configuring the Kafka nodes is not final and will be changed later.
+Most of the code implemented by this proposal is expected to be used for the final production-ready implementation.
+
+**The KRaft mode support suggested by this proposal will not be production-ready and should not be used outside of development.**
+
+### API changes
+
+In the initial implementation, there will be no changes to the `Kafka` custom resource and its API.
+When the KRaft mode is enabled, the operator will ignore any of the unsupported but required fields such as `.spec.zookeeper`.
+It will also validate the resource for any other unsupported features (such as authorization, JBOD storage etc.).
+
+The API is expected to change at a later phase before the KRaft support is considered production-ready.
+
+### KRaft deployment
+
+The initial implementation will support only a single type of KRaft deployment.
+All Kafka nodes will be created according to `.spec.kafka` section of the `Kafka` CR.
+It will respect the `.spec.kafka.replicas` field and deploy the corresponding number of Kafka nodes.
+All nodes will be assigned both the `controller` and `broker` KRaft roles.
+This deployment architecture is suitable for development and testing clusters.
+
+Other architectures, such as separate controller and broker nodes, will be not supported form the start.
+This is expected to change before the KRaft support is considered production-ready.
+
+### Feature Gate
+
+The new feature gate will be called `UseKraft`.
+It will be introduced in an alpha state and will be disabled by default.
+At this point, there is no timeline for graduation of this feature gate to beta or GA phase since it depends on things outside of out control.
+The schedule will be updated later as the KRaft development progress both in Apache Kafka as well as in Strimzi
+
+In the initial implementation, enabling or disabling this feature gate with pre-existing Kafka clusters will not be supported.
+Users will need to delete all clusters before enabling or disabling the feature gate.
+
+#### Dependency on other feature gates
+
+The `UseKraft` feature gate will be designed to work only with the `UseStrimziPodSets` feature gate enabled.
+The StrimziPodSets will be what Strimzi will use in the future instead of the StatefulSets.
+There is no plan to support the StatefulSets in the KRaft mode.
+The feature gate settings will be validated when the operator starts.
+
+### Limitations
+
+The initial implementation of this proposal has very limited set of features.
+These features might be missing because they are not supported at this point either by Apache Kafka or by Strimzi.
+Some of the known limitations are included in the following list:
+
+* Moving from Kafka clusters with ZooKeeper to KRaft clusters or the other way around.
+* Upgrades / downgrades of Apache Kafka versions or of the Strimzi operator are not supported. 
+  Users might need to delete the cluster, upgrade the operator and deploy a new Kafka cluster.
+* Entity Operator (both User and Topic operator) are not supported.
+* Authorization is not supported.
+* SCRAM-SHA-512 users are not supported
+* JBOD storage is not supported (the `type: jbod` storage can be used, but the JBOD array can contain only one disk)
+* Liveness and readiness probes might have limited functionality.
+* KRaft architectures using separate controller and broker nodes.
+
+As the implementation progresses, these features might be added later with separate PRs without a dedicated Strimzi Proposal.
+
+## Compatibility
+
+All changes introduced by this proposal will be feature-gated.
+This proposal should have no impact on any existing Kafka clusters deployed with ZooKeeper.
+
+## Rejected alternatives
+
+One of the alternatives which were rejected was to develop and maintain the KRaft implementation in a separate branch instead of doing it in the `main` branch using a feature gate.
+This was rejected, because it would make it harder to contribute the new features and it would make it also less accessible for regular users who might be interested to help with testing or further development of this feature.
+
+## Risks
+
+This proposal suggests to add new feature in an very early development phase.
+Maintaining this feature in the `main` branch might cause additional effort.
+It is also possible that some of the early code might be thrown away later.
+The expected benefits seem to currently out-weight the risks.

--- a/036-kraft-mode.md
+++ b/036-kraft-mode.md
@@ -45,7 +45,7 @@ The API is expected to change at a later phase before the KRaft support is consi
 The initial implementation will support only a single type of KRaft deployment.
 All Kafka nodes will be created according to `.spec.kafka` section of the `Kafka` CR.
 It will respect the `.spec.kafka.replicas` field and deploy the corresponding number of Kafka nodes.
-All nodes will be assigned both the `controller` and `broker` KRaft roles.
+All nodes will be assigned both the `controller` and `broker` KRaft roles (see the [KIP-500](https://cwiki.apache.org/confluence/display/KAFKA/KIP-500%3A+Replace+ZooKeeper+with+a+Self-Managed+Metadata+Quorum) for more details about the `controller` and `broker` roles).
 This deployment architecture is suitable for development and testing clusters.
 
 Other architectures, such as separate controller and broker nodes, will be not supported from the start.

--- a/036-kraft-mode.md
+++ b/036-kraft-mode.md
@@ -4,7 +4,7 @@
 
 The Apache Kafka project is working on removing its dependency on ZooKeeper.
 Because of the complexity of this task, the work is in progress already for more than one year.
-It was stared with the [Kafka Improvement Proposal 500 (KIP-500)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-500%3A+Replace+ZooKeeper+with+a+Self-Managed+Metadata+Quorum) and will continue for at least six to twelve months until all work is done and it is production-ready.
+It was started with the [Kafka Improvement Proposal 500 (KIP-500)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-500%3A+Replace+ZooKeeper+with+a+Self-Managed+Metadata+Quorum) and will continue for at least six to twelve months until all work is done and it is production-ready.
 Step by step, it removes the different dependencies on ZooKeeper.
 From the smaller things such as CLI tools or management APIs up to the complicated tasks such as quorum management and metadata management.
 It is based on _Apache Kafka Raft_ consensus protocol, which is also called _KRaft_.
@@ -24,7 +24,7 @@ This proposal suggests to add provisional support for the KRaft mode.
 It will be disabled by default and will be protected by a new feature gate.
 When the feature gate is enabled, it will use the KRaft mode to deploy the Kafka cluster.
 It will simplify development and testing of new Strimzi features in the KRaft mode.
-And it would also allow to help with testing of the KRaft mode it self and raise any issues in the Apache Kafka project.
+And it would also allow to help with testing of the KRaft mode itself and raise any issues in the Apache Kafka project.
 
 The KRaft support proposed here is called provisional, because the API in the Kafka CR for configuring the Kafka nodes is not final and will be changed later.
 Most of the code implemented by this proposal is expected to be used for the final production-ready implementation.
@@ -47,15 +47,15 @@ It will respect the `.spec.kafka.replicas` field and deploy the corresponding nu
 All nodes will be assigned both the `controller` and `broker` KRaft roles.
 This deployment architecture is suitable for development and testing clusters.
 
-Other architectures, such as separate controller and broker nodes, will be not supported form the start.
+Other architectures, such as separate controller and broker nodes, will be not supported from the start.
 This is expected to change before the KRaft support is considered production-ready.
 
 ### Feature Gate
 
 The new feature gate will be called `UseKraft`.
 It will be introduced in an alpha state and will be disabled by default.
-At this point, there is no timeline for graduation of this feature gate to beta or GA phase since it depends on things outside of out control.
-The schedule will be updated later as the KRaft development progress both in Apache Kafka as well as in Strimzi.
+At this point, there is no timeline for graduation of this feature gate to beta or GA phase since it depends on things outside of our control.
+The schedule will be updated later as the KRaft development progresses both in Apache Kafka as well as in Strimzi.
 
 In the initial implementation, enabling or disabling this feature gate with pre-existing Kafka clusters will not be supported.
 Users will need to delete all clusters before enabling or disabling the feature gate.
@@ -69,7 +69,7 @@ The feature gate settings will be validated when the operator starts.
 
 ### Limitations
 
-The initial implementation of this proposal has very limited set of features.
+The initial implementation of this proposal has a very limited set of features.
 These features might be missing because they are not supported at this point either by Apache Kafka or by Strimzi.
 Some of the known limitations are included in the following list:
 
@@ -97,7 +97,7 @@ This was rejected, because it would make it harder to contribute the new feature
 
 ## Risks
 
-This proposal suggests to add new feature in an very early development phase.
+This proposal suggests to add a new feature in a very early development phase.
 Maintaining this feature in the `main` branch might cause additional effort.
 It is also possible that some of the early code might be thrown away later.
-The expected benefits seem to currently out-weight the risks.
+The expected benefits seem to currently out-weigh the risks.

--- a/036-kraft-mode.md
+++ b/036-kraft-mode.md
@@ -3,29 +3,29 @@
 ## Motivation
 
 The Apache Kafka project is working on removing its dependency on ZooKeeper.
-Because of the complexity of this task, the work is in progress already for more than one year.
+Because of the complexity of this task, the work has already been in progress for more than a year.
 It was started with the [Kafka Improvement Proposal 500 (KIP-500)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-500%3A+Replace+ZooKeeper+with+a+Self-Managed+Metadata+Quorum) and will continue for at least six to twelve months until all work is done and it is production-ready.
-Step by step, it removes the different dependencies on ZooKeeper.
-From the smaller things such as CLI tools or management APIs up to the complicated tasks such as quorum management and metadata management.
-It is based on _Apache Kafka Raft_ consensus protocol, which is also called _KRaft_.
+Step-by-step, Apache Kafka will remove all dependencies on ZooKeeper. 
+These range from smaller dependencies, such as CLI and management tools, to more complex dependencies involving  quorum and metadata management. 
+A consensus protocol called _Apache Kafka Raft_ (or _KRaft_) will replace ZooKeeper. 
 This is what gives the name to this proposal as well as to the feature gate discussed later.
 
 Strimzi aims to support the ZooKeeper-less Kafka and the KRaft protocol.
 The issue [strimzi/strimzi-kafka-operator#5615](https://github.com/strimzi/strimzi-kafka-operator/issues/5615) can be used to track the overall progress and production-ready support for KRaft.
-Since the announcement of the KIP-500, we are making sure that Strimzi is as ready as possible for when the KRaft mode becomes production-ready.
-This includes for example adopting the new Kafka Admin APIs using Kafka instead of ZooKeeper in components such as User Operator or Cruise Control.
+Since the announcement of the KIP-500, we have been making sure that Strimzi is as ready as possible for when the KRaft mode becomes production-ready.
+For example, Strimzi has adopted the new Kafka Admin APIs that use Kafka instead of ZooKeeper in components like the User Operator and Cruise Control.
 But right now, you cannot really use Strimzi to run Kafka with the KRaft mode enabled.
 That makes it hard to continue working on some of the additional tasks needed to have Strimzi production-ready with KRaft in the future.
-For example the work on the readiness / liveness probes, Topic Operator improvements, upgrades etc.
-All of these tasks will be easier to work on with Strimzi supporting the KRaft mode out-of-the-box.
+For example, work is pending on readiness / liveness probes, Topic Operator improvements, and upgrades.
+Task such as these will be easier to work on with Strimzi supporting the KRaft mode out-of-the-box.
 
 ## Proposal
 
-This proposal suggests to add provisional support for the KRaft mode.
+This proposal suggests adding provisional support for the KRaft mode.
 It will be disabled by default and will be protected by a new feature gate.
 When the feature gate is enabled, it will use the KRaft mode to deploy the Kafka cluster.
 It will simplify development and testing of new Strimzi features in the KRaft mode.
-And it would also allow to help with testing of the KRaft mode itself and raise any issues in the Apache Kafka project.
+And it will also help with testing of the KRaft mode and raising any issues that arise in the Apache Kafka project.
 
 The KRaft support proposed here is called provisional, because the API in the Kafka CR for configuring the Kafka nodes is not final and will be changed later.
 Most of the code implemented by this proposal is expected to be used for the final production-ready implementation.
@@ -80,7 +80,7 @@ Some of the known limitations are included in the following list:
 * Entity Operator (both User and Topic operator) are not supported.
 * Authorization is not supported.
 * SCRAM-SHA-512 users are not supported.
-* JBOD storage is not supported (the `type: jbod` storage can be used, but the JBOD array can contain only one disk)
+* JBOD storage is not supported (the `type: jbod` storage can be used, but the JBOD array can contain only one disk).
 * Liveness and readiness probes are disabled.
 * KRaft architectures using separate controller and broker nodes.
 
@@ -94,11 +94,11 @@ This proposal should have no impact on any existing Kafka clusters deployed with
 ## Rejected alternatives
 
 One of the alternatives which were rejected was to develop and maintain the KRaft implementation in a separate branch instead of doing it in the `main` branch using a feature gate.
-This was rejected, because it would make it harder to contribute the new features and it would make it also less accessible for regular users who might be interested to help with testing or further development of this feature.
+This was rejected, because it would make it harder to contribute the new features and it would also make it less accessible for regular users who might be interested to help with testing or further development of this feature.
 
 ## Risks
 
-This proposal suggests to add a new feature in a very early development phase.
+This proposal suggests adding a new feature in a very early development phase.
 Maintaining this feature in the `main` branch might cause additional effort.
 It is also possible that some of the early code might be thrown away later.
 The expected benefits seem to currently out-weigh the risks.

--- a/036-kraft-mode.md
+++ b/036-kraft-mode.md
@@ -55,7 +55,7 @@ This is expected to change before the KRaft support is considered production-rea
 The new feature gate will be called `UseKraft`.
 It will be introduced in an alpha state and will be disabled by default.
 At this point, there is no timeline for graduation of this feature gate to beta or GA phase since it depends on things outside of out control.
-The schedule will be updated later as the KRaft development progress both in Apache Kafka as well as in Strimzi
+The schedule will be updated later as the KRaft development progress both in Apache Kafka as well as in Strimzi.
 
 In the initial implementation, enabling or disabling this feature gate with pre-existing Kafka clusters will not be supported.
 Users will need to delete all clusters before enabling or disabling the feature gate.
@@ -78,7 +78,7 @@ Some of the known limitations are included in the following list:
   Users might need to delete the cluster, upgrade the operator and deploy a new Kafka cluster.
 * Entity Operator (both User and Topic operator) are not supported.
 * Authorization is not supported.
-* SCRAM-SHA-512 users are not supported
+* SCRAM-SHA-512 users are not supported.
 * JBOD storage is not supported (the `type: jbod` storage can be used, but the JBOD array can contain only one disk)
 * Liveness and readiness probes might have limited functionality.
 * KRaft architectures using separate controller and broker nodes.

--- a/036-kraft-mode.md
+++ b/036-kraft-mode.md
@@ -11,8 +11,9 @@ It is based on _Apache Kafka Raft_ consensus protocol, which is also called _KRa
 This is what gives the name to this proposal as well as to the feature gate discussed later.
 
 Strimzi aims to support the ZooKeeper-less Kafka and the KRaft protocol.
+The issue [strimzi/strimzi-kafka-operator#5615](https://github.com/strimzi/strimzi-kafka-operator/issues/5615) can be used to track the overall progress and production-ready support for KRaft.
 Since the announcement of the KIP-500, we are making sure that Strimzi is as ready as possible for when the KRaft mode becomes production-ready.
-This includes for example adopting the new APIs based on Kafka instead of ZooKeeper in components such as User Operator or Cruise Control.
+This includes for example adopting the new Kafka Admin APIs using Kafka instead of ZooKeeper in components such as User Operator or Cruise Control.
 But right now, you cannot really use Strimzi to run Kafka with the KRaft mode enabled.
 That makes it hard to continue working on some of the additional tasks needed to have Strimzi production-ready with KRaft in the future.
 For example the work on the readiness / liveness probes, Topic Operator improvements, upgrades etc.
@@ -52,7 +53,7 @@ This is expected to change before the KRaft support is considered production-rea
 
 ### Feature Gate
 
-The new feature gate will be called `UseKraft`.
+The new feature gate will be called `UseKRaft`.
 It will be introduced in an alpha state and will be disabled by default.
 At this point, there is no timeline for graduation of this feature gate to beta or GA phase since it depends on things outside of our control.
 The schedule will be updated later as the KRaft development progresses both in Apache Kafka as well as in Strimzi.
@@ -62,10 +63,10 @@ Users will need to delete all clusters before enabling or disabling the feature 
 
 #### Dependency on other feature gates
 
-The `UseKraft` feature gate will be designed to work only with the `UseStrimziPodSets` feature gate enabled.
+The `UseKRaft` feature gate will be designed to work only with the `UseStrimziPodSets` feature gate enabled (see the [StatefulSet removal proposal](https://github.com/strimzi/proposals/blob/main/031-statefulset-removal.md) for more details).
 The StrimziPodSets will be what Strimzi will use in the future instead of the StatefulSets.
 There is no plan to support the StatefulSets in the KRaft mode.
-The feature gate settings will be validated when the operator starts.
+The feature gate settings will be validated when the operator starts to ensure that both feature gates are set correctly.
 
 ### Limitations
 
@@ -80,7 +81,7 @@ Some of the known limitations are included in the following list:
 * Authorization is not supported.
 * SCRAM-SHA-512 users are not supported.
 * JBOD storage is not supported (the `type: jbod` storage can be used, but the JBOD array can contain only one disk)
-* Liveness and readiness probes might have limited functionality.
+* Liveness and readiness probes are disabled.
 * KRaft architectures using separate controller and broker nodes.
 
 As the implementation progresses, these features might be added later with separate PRs without a dedicated Strimzi Proposal.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository list of proposals for the Strimzi project. A template for new pr
 
 |  #  | Title                                                                 |
 | :-: |:----------------------------------------------------------------------|
+| 35  | [KRaft support: ZooKeeper-less Kafka](./036-kraft-mode.md) |
 | 35  | [Extending the `KafkaRebalance` resource with rebalance types to help scaling the Apache Kafka cluster](./035-rebalance-types-scaling-brokers.md) |
 | 34  | [Deprecate and remove MirrorMaker 2 extensions](./034-deprecate-and-remove-mirror-maker-2-extensions.md) |
 | 33  | [Service Binding](./033-service-binding.md) |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository list of proposals for the Strimzi project. A template for new pr
 
 |  #  | Title                                                                 |
 | :-: |:----------------------------------------------------------------------|
-| 35  | [KRaft support: ZooKeeper-less Kafka](./036-kraft-mode.md) |
+| 36  | [KRaft support: ZooKeeper-less Kafka](./036-kraft-mode.md) |
 | 35  | [Extending the `KafkaRebalance` resource with rebalance types to help scaling the Apache Kafka cluster](./035-rebalance-types-scaling-brokers.md) |
 | 34  | [Deprecate and remove MirrorMaker 2 extensions](./034-deprecate-and-remove-mirror-maker-2-extensions.md) |
 | 33  | [Service Binding](./033-service-binding.md) |


### PR DESCRIPTION
This PR proposes to add initial support for ZooKeeper-less Kafka / KRaft mode. The initial proposal contains many limitations and it does not cover the API changes expected to be done before the production-ready KRaft support. But it should simplify the development of the KRaft mode in Strimzi and make it easier to test it.

This proposal expects the code to be mostly based on my [_Escape the Zoo_ prototype branch](https://github.com/strimzi/strimzi-kafka-operator/compare/main...scholzj:escape-the-zoo-2?expand=1).