### PR TITLE
Update the Strimzi releases when the feature gates are expected to graduate

### DIFF
--- a/045-Stable-identities-for-Kafka-Connect-worker-nodes.md
+++ b/045-Stable-identities-for-Kafka-Connect-worker-nodes.md
@@ -94,9 +94,9 @@ The following table shows the expected graduation of the `StableConnectIdentitie
 
 | Phase | Strimzi versions       | Default state                                          |
 |:------|:-----------------------|:-------------------------------------------------------|
-| Alpha | 0.34, 0.35             | Disabled by default                                    |
-| Beta  | 0.36, 0.37             | Enabled by default                                     |
-| GA    | 0.38 and newer         | Enabled by default (without possibility to disable it) |
+| Alpha | 0.34 - 0.36            | Disabled by default                                    |
+| Beta  | 0.37 - 0.38            | Enabled by default                                     |
+| GA    | 0.39 and newer         | Enabled by default (without possibility to disable it) |
 
 ### Migration from Kubernetes Deployments to StrimziPodSets
 

--- a/050-Kafka-Node-Pools.md
+++ b/050-Kafka-Node-Pools.md
@@ -612,9 +612,9 @@ The following table shows the expected graduation of the `KafkaNodePools` featur
 
 | Phase | Strimzi versions       | Default state                                          |
 |:------|:-----------------------|:-------------------------------------------------------|
-| Alpha | 0.35 - 0.37            | Disabled by default                                    |
-| Beta  | 0.38 - 0.39            | Enabled by default                                     |
-| GA    | 0.40 and newer         | Enabled by default (without possibility to disable it) |
+| Alpha | 0.36 - 0.38            | Disabled by default                                    |
+| Beta  | 0.39 - 0.40            | Enabled by default                                     |
+| GA    | 0.41 and newer         | Enabled by default (without possibility to disable it) |
 
 The main purpose of the feature gate is in this case to protect users from a feature which is not mature enough and might be removed in future versions.
 Only small parts of the code will actually depend on the feature gate being enabled or disabled.


### PR DESCRIPTION
This PR updates the graduation releases for the Node Pool and Stable Connect identities feature gates:
* Node pools were merged only in 0.36 instead of the initially expected 0.35
* Moving StableConnectIdentities to beta was postponed because of the informer issues in the Kubernetes Client