### PR TITLE
Update #046 to reflect the recent change in upstream Kafka

### DIFF
--- a/046-kraft-liveness-readiness.md
+++ b/046-kraft-liveness-readiness.md
@@ -1,4 +1,5 @@
 # Liveness and Readiness probes in a KRaft Kafka cluster
+> Note: This proposal has been updated since its initial merge.
 
 This proposal describes the liveness and readiness probes that should be put in place 
 for a Kafka cluster that is using KRaft rather than ZooKeeper. This includes a KRaft 
@@ -70,7 +71,7 @@ The proposed probes are:
 
 The proposed probes are:
 
-* Liveness: broker is listening on the port 9091 which is configured in `inter.broker.listener.name`
+* Liveness: the Java process in the container is running
 * Readiness: the BrokerState metric >=3 && != 127
 
 **Note:** This means the brokers will not become ready until a majority of the controllers 
@@ -159,7 +160,7 @@ This will be used for the broker only and combined readiness checks later and wi
 ### Phase 2 - Strimzi adds support for broker only and controller only modes
 
 * Controller only pod liveness and readiness checks are fully implemented to match this proposal.
-* Broker only pods are marked as both alive and ready if listening on port 9091.
+* Broker only pods are marked as both alive and ready when there is a Java process running (no change from phase 1).
 * Combined mode pods are marked as both alive and ready when there is a Java process running (no change from phase 1).
 
 ### Phase 3 - KafkaRoller is updated to take the existence of controller pods and status of controller quorum into account when deciding whether to roll pods


### PR DESCRIPTION
https://issues.apache.org/jira/browse/KAFKA-14658 requires small change to the existing proposal
https://github.com/strimzi/proposals/blob/main/046-kraft-liveness-readiness.md. 

Before this upstream change, Kafka broker port would be opened before the log recovery. Based on this logic, #046 proposed liveness probe for broker only mode to listen on the port 9091 which is configured in inter.broker.listener.name. However, after the upstream change in KAFKA-14658, the port is now opened when broker is ready to accept traffic which happens after log recovery. If the log recovery takes a long time, then using the listening on the port for liveness check risks Kubernetes killing the broker.

#046 proposed liveness probe for controller and combined mode to have running Java process in the container. The reason for this was because of very similar issue. For controller mode, the log recovery happens before socket bind, which happens before socket listen (the LISTEN state), so if recovery of the __cluster_metadata log takes a long time then using the port for a liveness check risks Kubernetes killing the controller. 

Therefore I think it makes sense to change broker only mode to have the same liveness probe (running Java process in the container) as the controller and combined mode. 