### PR TITLE
Allow running ZooKeeper and KRaft based clusters in parallel

### DIFF
--- a/057-marking-zk-kraft-clusters.md
+++ b/057-marking-zk-kraft-clusters.md
@@ -31,7 +31,7 @@ The possible values would be:
 
 This way, during the reconciliation, the operator is able to detect a ZooKeeper-based cluster avoiding the warning, as described in the "Current" section, but allowing the user to operate it.
 On the KRaft side, the annotation would be needed to have the operator reconciling the corresponding `Kafka` custom resource.
-Without the annotation, but the `UseKRaft` feature gate enabled, the operator would ignore the cluster.
+Without the annotation, but the `UseKRaft` feature gate enabled, the operator would try to handle it as a ZooKeeper-based one.
 This approach is actually the same as for the node pools: enabling the `KafkaNodePools` feature gate on the operator is not enough and the user needs to apply the `strimzi.io/node-pools: enabled` annotation on the `Kafka` custom resource using node pools for brokers (and controllers, if KRaft enabled as well).
 
 The same annotation could be even used in the proposal [PR#90](https://github.com/strimzi/proposals/pull/90) for handling the ZooKeeper to KRaft migration steps.

--- a/057-marking-zk-kraft-clusters.md
+++ b/057-marking-zk-kraft-clusters.md
@@ -1,0 +1,53 @@
+# Marking ZooKeeper and KRaft based clusters for KRaft enabled operators
+
+This proposal is about providing to the Strimzi Cluster Operator a way to "detect" if an Apache Kafka cluster is ZooKeeper or KRaft based when the KRaft feature gate is enabled.
+
+## Current situation
+
+Currently, when the `UseKRaft` feature gate is enabled, the operator expects all the Apache Kafka clusters being KRaft-based.
+There is no way to differentiate between clusters running in ZooKeeper or KRaft mode.
+When a `Kafka` custom resource, configured to use ZooKeeper for metadata, is reconciled, the operator detects it with a missing KRaft controllers configuration logging the following warning:
+
+```shell
+io.strimzi.operator.common.model.InvalidResourceException: Tha Kafka cluster my-cluster is invalid: [At least one KafkaNodePool with the controller role and at least one replica is required when KRaft mode is enabled]
+```
+
+In this case, the reconciliation fails and the cluster is not operated at all.
+It means that the operator doesn't take any actions on changes applied by the user to the `spec.kafka` or `spec.zookeeper` in the `Kafka` custom resource.
+
+## Motivation
+
+Leaving a ZooKeeper-based cluster not operated when the `UseKRaft` feature gate is enabled looks like a bad thing for the user, until the ZooKeeper support will be completely removed.
+Before that, the user should be able to have both ZooKeeper and KRaft based clusters running and operated when the `UseKRaft` feature gate is enabled.
+Also, taking into account the future ZooKeeper to KRaft migration process, as described in the proposal [PR#90](https://github.com/strimzi/proposals/pull/90), it would help the operator migration component to detect which cluster is ZooKeeper-based so "migrate-able" and which one is already KRaft-based.
+
+## Proposal
+
+The proposal is about adding a new `strimzi.io/kraft` annotation to the `Kafka` custom resource, to be applied by the user, in order to identify a ZooKeeper or KRaft based cluster.
+The possible values would be:
+
+* `disabled` (or missing): identifies a ZooKeeper-based cluster.
+* `enabled`: identifies a KRaft-based cluster.
+
+This way, during the reconciliation, the operator is able to detect a ZooKeeper-based cluster avoiding the warning, as described in the "Current" section, but allowing the user to operate it.
+On the KRaft side, the annotation would be needed to have the operator reconciling the corresponding `Kafka` custom resource.
+Without the annotation, but the `UseKRaft` feature gate enabled, the operator would ignore the cluster.
+This approach is actually the same as for the node pools: enabling the `KafkaNodePools` feature gate on the operator is not enough and the user needs to apply the `strimzi.io/node-pools: enabled` annotation on the `Kafka` custom resource using node pools for brokers (and controllers, if KRaft enabled as well).
+
+The same annotation could be even used in the proposal [PR#90](https://github.com/strimzi/proposals/pull/90) for handling the ZooKeeper to KRaft migration steps.
+
+## Affected/not affected projects
+
+The Strimzi Cluster Operator is the only project affected by this proposal.
+Its logic needs to be updated in order to be able to handle the new `strimzi.io/kraft` annotation (or the missing of it).
+No other projects in the Strimzi ecosystem are impacted by this proposal.
+
+## Compatibility
+
+If the user is running the operator with `UseKRaft` feature gate enabled, it will detect ZooKeeper-based cluster allowing to operate them again.
+If the user has a KRaft-based cluster deployed, it would be ignored and not reconciled anymore, unless the user applies `strimzi.io/kraft: enabled` annotation on it.
+Breaking this backward compatibility is expected taking into account that the KRaft support in Strimzi is still behind a feature gate and should be considered just for development purposes. 
+
+## Rejected alternatives
+
+As first iteration of the proposal there are no rejected alternatives.

--- a/057-run-zk-kraft-clusters-parallel.md
+++ b/057-run-zk-kraft-clusters-parallel.md
@@ -5,7 +5,7 @@ It changes the way the Strimzi Cluster Operator handles ZooKeeper and KRaft base
 
 ## Current situation
 
-Currently, when the `UseKRaft` feature gate is enabled (together with the required `KafkaNodePools` one), the operator expects all the already running Apache Kafka clusters being KRaft-based.
+Currently, when the `UseKRaft` feature gate is enabled (together with the required `KafkaNodePools` one), the operator expects the Apache Kafka clusters already running to be KRaft-based.
 It means that the `Kafka` custom resources are configured together with `KafkaNodePool`(s) with `broker` and `controller` roles.
 There is no way to differentiate between clusters running in ZooKeeper or KRaft mode.
 When a `Kafka` custom resource is configured to actually use ZooKeeper or it's just badly configured but supposed to be KRaft-based, the operator detects it as having a missing KRaft controllers configuration and logs the following warning:
@@ -45,7 +45,7 @@ Without the annotation, but the `UseKRaft` feature gate enabled, the operator wo
 | `+UseKRaft`           | `enabled`                     | KRaft reconciliation     |
 | `+UseKRaft`           | missing or anything else      | ZooKeeper reconciliation |
 
-The `UseKRaft` feature gate does currently not support any upgrades of KRaft clusters.
+The `UseKRaft` feature gate does not currently support any upgrades of KRaft clusters.
 It is expected to be used only for short-lived clusters used for development and testing.
 So no clusters are expected to exist.
 Therefore adding the annotation now does not present any backwards compatibility issues.

--- a/057-run-zk-kraft-clusters-parallel.md
+++ b/057-run-zk-kraft-clusters-parallel.md
@@ -37,6 +37,14 @@ The possible values would be:
 This way, during the reconciliation, the operator is able to "detect" a ZooKeeper-based cluster avoiding the warning and allowing the user to operate it.
 On the KRaft side, the annotation would be needed to have the operator reconciling the corresponding `Kafka` custom resource.
 Without the annotation, but the `UseKRaft` feature gate enabled, the operator would try to handle it as a ZooKeeper-based one.
+
+| Operator Feature Gate | `strimzi.io/kraft` annotation | Operator behaviour       |
+|-----------------------|-------------------------------|--------------------------|
+| `-UseKRaft`           | `enabled`                     | Ignore annotation        |
+| `-UseKRaft`           | missing or anything else      | ZooKeeper reconciliation |
+| `+UseKRaft`           | `enabled`                     | KRaft reconciliation     |
+| `+UseKRaft`           | missing or anything else      | ZooKeeper reconciliation |
+
 The `UseKRaft` feature gate does currently not support any upgrades of KRaft clusters.
 It is expected to be used only for short-lived clusters used for development and testing.
 So no clusters are expected to exist.

--- a/057-run-zk-kraft-clusters-parallel.md
+++ b/057-run-zk-kraft-clusters-parallel.md
@@ -8,10 +8,10 @@ It changes the way the Strimzi Cluster Operator handles ZooKeeper and KRaft base
 Currently, when the `UseKRaft` feature gate is enabled (together with the required `KafkaNodePools` one), the operator expects all the already running Apache Kafka clusters being KRaft-based.
 It means that the `Kafka` custom resources are configured together with `KafkaNodePool`(s) with `broker` and `controller` roles.
 There is no way to differentiate between clusters running in ZooKeeper or KRaft mode.
-When a `Kafka` custom resource is configured to actually use ZooKeeper or it's just badly configured but supposed to be KRaft based, the operator detects it as having a missing KRaft controllers configuration and logs the following warning:
+When a `Kafka` custom resource is configured to actually use ZooKeeper or it's just badly configured but supposed to be KRaft-based, the operator detects it as having a missing KRaft controllers configuration and logs the following warning:
 
 ```shell
-io.strimzi.operator.common.model.InvalidResourceException: Tha Kafka cluster my-cluster is invalid: [At least one KafkaNodePool with the controller role and at least one replica is required when KRaft mode is enabled]
+io.strimzi.operator.common.model.InvalidResourceException: The Kafka cluster my-cluster is invalid: [At least one KafkaNodePool with the controller role and at least one replica is required when KRaft mode is enabled]
 ```
 
 In this case, the reconciliation fails and the cluster is not operated at all.
@@ -38,7 +38,7 @@ This way, during the reconciliation, the operator is able to "detect" a ZooKeepe
 On the KRaft side, the annotation would be needed to have the operator reconciling the corresponding `Kafka` custom resource.
 Without the annotation, but the `UseKRaft` feature gate enabled, the operator would try to handle it as a ZooKeeper-based one.
 The `UseKRaft` feature gate does currently not support any upgrades of KRaft clusters.
-It is expected to be used only for short-lives clusters used for development and testing.
+It is expected to be used only for short-lived clusters used for development and testing.
 So no clusters are expected to exist.
 Therefore adding the annotation now does not present any backwards compatibility issues.
 Only ZooKeeper-based clusters are expected and newly created KRaft-based clusters having the `strimzi.io/kraft: enabled`.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ This repository list of proposals for the Strimzi project. A template for new pr
 
 |  #  | Title                                                                 |
 | :-: |:----------------------------------------------------------------------|
-| 56  | [Add ability to create Cruise Control REST API users](./056-cruise-control-api-users.md) 
-| 55  | [Infinite auto-restart of Apache Kafka connectors](./055-infinite-auto-restart-of-Kafka-connectors.md) 
+| 57  | [Allow running ZooKeeper and KRaft based clusters in parallel](./057-run-zk-kraft-clusters-parallel.md) |
+| 56  | [Add ability to create Cruise Control REST API users](./056-cruise-control-api-users.md) |
+| 55  | [Infinite auto-restart of Apache Kafka connectors](./055-infinite-auto-restart-of-Kafka-connectors.md) |
 | 54  | [Support stopping Kafka Connect connectors](./054-stopping-kafka-connect-connectors.md) |
 | 53  | [Record Reconciled Version in Kafka Custom Resource status](./053-record-reconciled-versions.md) |
 | 52  | [Kubernetes Server Side Apply](./052-k8s-server-side-apply.md) |


### PR DESCRIPTION
This PR adds a proposal to allow running ZooKeeper and KRaft based clusters in parallel when the KRaft feature gate is enabled.