### PR TITLE
Add topic replication factor change

### DIFF
--- a/066-topic-replication-factor-change.md
+++ b/066-topic-replication-factor-change.md
@@ -167,7 +167,7 @@ The following environment variables will be set by the Cluster Operator for cons
 | STRIMZI_CRUISE_CONTROL_AUTH_ENABLED   | Boolean | false   | Whether Basic authentication is enabled                       |
 
 With the Cluster Operator deployment, the certificate chain in PEM format and the admin user credentials for the Cruise Control REST API will be automatically mounted in the Topic Operator container.
-Instead, with the standalone deployment, the user will have to mount: certificate chain in `/etc/tls-sidecar/cluster-ca-certs/ca.crt`, credentials in `/etc/eto-cc-api/cruise-control.apiToAdminUsername` and `/etc/eto-cc-api/cruise-control.apiToAdminPassword`.
+Instead, with the standalone deployment, the user will have to mount: certificate chain in `/etc/tls-sidecar/cluster-ca-certs/ca.crt`, credentials in `/etc/eto-cc-api/topic-operator.apiAdminName` and `/etc/eto-cc-api/topic-operator.apiAdminPassword`.
 
 ### KafkaTopic CRD changes
 

--- a/066-topic-replication-factor-change.md
+++ b/066-topic-replication-factor-change.md
@@ -64,7 +64,7 @@ The [`topic_configuration`](https://github.com/linkedin/cruise-control/wiki/REST
 Once accepted, the replication factor change is put into the Cruise Control's task queue and executed asynchronously.
 
 The two required parameters for this endpoint are `topic` (regular expression to specify subject topics) and `replication_factor` (target replication factor).
-In order to group multiple changes in the same request to Cruise Control, the Topic Operator uses a JSON payload containing topics grouped by their replication factor.
+In order to group multiple changes in the same request to Cruise Control, the Topic Operator uses a JSON payload containing topics grouped by their replication factor, which replaces the required parameters.
 
 This is useful with bulk replicas change, which can happen in some edge cases.
 A potentially big backlog of messages may be created when the Topic Operator is not running, or there is an issue with Cruise Control or Kafka.

--- a/066-topic-replication-factor-change.md
+++ b/066-topic-replication-factor-change.md
@@ -1,0 +1,271 @@
+# Topic replication factor change
+
+In Kafka, the unit of replication is the topic partition.
+The total number of partition replicas, including the leader, constitutes the replication factor.
+
+The replication factor is configured at the topic level, and can be used to enable strong durability and fault tolerance.
+When the Kafka cluster is healthy and a broker is down, another one can serve the data of topics with replication factor greater than one.
+A tradeoff is that each topic partition will take up an amount of storage equal to its size times the replication factor value.
+The cluster `default.replication.factor` configuration is used when a new topic is created without specifying the replication factor.
+
+When new messages arrives, they are first written into the operating system's page cache, and then flushed to disk asynchronously.
+If the Kafka JVM crashes for whatever reason, recent messages are still in the page cache, and can be flushed by the operating system.
+However, this doesn't protect from data loss when the machine crashes, and this is why enabling topic replication is important.
+To further improve fault tolerance, a rack-aware Kafka cluster can be used to distribute topic replicas evenly across data centers in the same geographic region.
+
+Once a topic is created, it is possible to change its replication factor using a command line tool.
+This operation is quite complicated on busy clusters with thousands of partitions, because the user have to decide leader and partition movements without causing cluster unbalance.
+
+The goal of this proposal is to allow Strimzi users to change the topic replication factor by simply updating the KafkaTopic resource.
+Unless specified, we always refer to the Unidirectional Topic Operator implementation.
+
+## Current situation
+
+When the user change the `KafkaTopic.spec.replicas` field, the Topic Operator fails the reconciliation, and the resource becomes not ready. 
+An error is reported in Topic Operator logs and KafkaTopic resource status.
+
+> Replication factor change not supported, but required for partitions\
+> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,\
+> 22, 23, 24]
+
+The only [documented solution](https://strimzi.io/docs/operators/latest/deploying#proc-changing-topic-replicas-str) is to use the kafka-reassign-partitions.sh tool by spinning up a separate interactive pod.
+This is far from user friendly, and the user is in charge of doing the calculations to determine the best broker to host a new replica, or which replica needs to be dropped.
+
+When data loss is not a problem, the user can simply delete and recreate the KafkaTopic resource with the desired replication factor.
+This is not really an option for most use cases.
+
+## Motivation
+
+The topic replication factor change feature will provide a much better cloud-native experience for Strimzi users.
+They will be able to change the topic replication factor by simply updating the KafkaTopic resource, which may also happen through a GitOps pipeline.
+
+This is a non exhaustive list of use cases that will become significantly easier:
+
+- Set a lower replication factor for non-critical topics to reduce the infrastructure costs (compute, storage and network).
+- Set a lower replication factor to deal with resource shortage (trade-off between fault-tolerance and resource utilization).
+- Set a higher replication factor for critical topics to improve durability and fault tolerance.
+
+## Proposal
+
+The replication factor change feature can be implemented by integrating the Topic Operator with Cruise Control.
+The Cluster Operator is already integrated with Cruise Control, so we can factor out the existing logic and classes.
+
+Cruise Control creates a task for each operation, such as topic configuration and cluster rebalance.
+A task is first created in the Active state, then moves to InExecution, and finally to Completed or CompletedWithError.
+At most `max.active.user.tasks` tasks can be Active at the same time (5 by default), and only one task can be InExecution at any given time.
+During the execution, a task is divided in one or more batches, which are then executed one after the other.
+
+### Topic configuration
+
+The [`topic_configuration`](https://github.com/linkedin/cruise-control/wiki/REST-APIs#change-kafka-topic-configuration) endpoint is used to request a topic configuration update, and currently only supports replication factor changes.
+Once accepted, the replication factor change is put into the Cruise Control's task queue and executed asynchronously.
+
+If partition's current replication factor is less than target replication factor, new replicas are added to the partition in two steps.
+Tentatively add new replicas in a rack-aware, round-robin way, and then further optimize location of new replicas with provided or default Goal list (same heuristic of the rebalance).
+Rack awareness property is guaranteed only when the rack information is in metadata, and target replication factor is less than number or racks.
+
+If the current replication factor of partition is larger than target replication factor, one or more follower replicas are removed from the partition.
+Replicas are removed following the reverse order of position in replica list of partition.
+
+The two required parameters for this endpoint are `topic` (regular expression to specify subject topics) and `replication_factor` (target replication factor).
+In order to batch multiple changes in the same request, the Topic Operator uses a JSON payload containing topics grouped by their replication factor.
+This is useful in case of bulk replicas change (e.g. GitOps updates), or when a backlog of replicas changes is created because of a long rebalance task.
+
+```sh
+$ curl -vv -X POST -H "Content-Type: application/json" -d '{replication_factor:{topic_by_replication_factor:{2:topic1|topic3|topic4,3:topic2|topic5}}}' \
+  "http://localhost:9090/kafkacruisecontrol/topic_configuration?skip_rack_awareness_check=true&dryrun=false&json=true" | jq
+> POST /kafkacruisecontrol/topic_configuration?skip_rack_awareness_check=true&dryrun=false&json=true HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/8.0.1
+> Accept: */*
+> 
+} [91 bytes data]
+< HTTP/1.1 200 OK
+< Date: Thu, 07 Dec 2023 14:58:55 GMT
+< Set-Cookie: JSESSIONID=node0lfkx183ijq4pjkkjahsegfmp30.node0; Path=/
+< Expires: Thu, 01 Jan 1970 00:00:00 GMT
+< User-Task-ID: 5344ca89-351f-4565-8d0f-9aade00e053d
+< Content-Type: application/json;charset=utf-8
+< Cruise-Control-Version: 2.5.77-SNAPSHOT
+< Cruise-Control-Commit_Id: 535ea07e8847990cc02dde1f1be99b387dbeaf5b
+< Content-Length: 17051
+< Server: Jetty(9.4.52.v20230823)
+< 
+{ [17321 bytes data]
+{
+  "summary": {
+    "numIntraBrokerReplicaMovements": 0,
+    "numReplicaMovements": 125,
+    "onDemandBalancednessScoreAfter": 100,
+    "intraBrokerDataToMoveMB": 0,
+    "monitoredPartitionsPercentage": 100,
+    "provisionRecommendation": "",
+    "excludedBrokersForReplicaMove": [],
+    "excludedBrokersForLeadership": [],
+    "provisionStatus": "RIGHT_SIZED",
+    "onDemandBalancednessScoreBefore": 100,
+    "recentWindows": 5,
+    "dataToMoveMB": 0,
+    "excludedTopics": [],
+    "numLeaderMovements": 0
+  }
+  ...
+```
+
+The `skip_rack_awareness_check` parameter configures whether to skip the rack awareness sanity check or not (disabled by default).
+In case of a single-rack deployment, the Topic Operator automatically enables `skip_rack_awareness_check` to allow replication factor changes.
+
+The `goals` parameter is a comma separated list of goals used to generate the automatic cluster rebalance for the replication factor change.
+This is configurable for all endpoints in `Kafka.spec.cruiseControl.config` using the `default.goals` property.
+
+The `replication_throttle` parameter is an upper bound on the bandwidth used to move replicas (bytes per second).
+This is configurable for all endpoints in `Kafka.spec.cruiseControl.config` using the `default.replication.throttle` property.
+
+### User tasks
+
+The [`user_tasks`](https://github.com/linkedin/cruise-control/wiki/REST-APIs#query-the-user-request-result) endpoint is used to periodically check the replicas change tasks state.
+The only required parameter is the `User-Task-ID`, which is returned by the `topic_configuration` response.
+
+```sh
+$ curl -s "localhost:9090/kafkacruisecontrol/user_tasks?user_task_ids=5344ca89-351f-4565-8d0f-9aade00e053d&json=true" | jq
+{
+  "userTasks": [
+    {
+      "Status": "Completed",
+      "ClientIdentity": "127.0.0.1",
+      "RequestURL": "POST /kafkacruisecontrol/topic_configuration?topic=my-topic&replication_factor=2&skip_rack_awareness_check=true&dryrun=false&json=true",
+      "UserTaskId": "5344ca89-351f-4565-8d0f-9aade00e053d",
+      "StartMs": "1701961135978"
+    }
+  ],
+  "version": 1
+}
+```
+
+### Configuration parameters
+
+The Topic Operator needs to authenticate and send HTTP requests to the Cruise Control's REST API.
+The following environment variables are set by the Cluster Operator when Cruise Control is configured in Kafka resource, or manually by the user in case of standalone deployment:
+
+| Name                                   | Type    | Default | Description                                                   |
+|:---------------------------------------|---------|---------|---------------------------------------------------------------|
+| STRIMZI_CRUISE_CONTROL_ENABLED         | Boolean | false   | Whether Cruise Control integration is enabled                 |
+| STRIMZI_CRUISE_CONTROL_NAMESPACE       | String  | ""      | Namespace where Cruise Control is running                     |
+| STRIMZI_CRUISE_CONTROL_HOSTNAME        | String  | ""      | Cruise Control hostname                                       |
+| STRIMZI_CRUISE_CONTROL_PORT            | Integer | 9090    | Cruise Control port                                           |
+| STRIMZI_CRUISE_CONTROL_SSL_ENABLED     | Boolean | false   | Whether SSL encryption is enabled                             |
+| STRIMZI_CRUISE_CONTROL_AUTH_ENABLED    | Boolean | false   | Whether Basic authentication is enabled                       |
+| STRIMZI_CRUISE_CONTROL_RACK_ENABLED    | Boolean | false   | Whether rack awareness is enabled in the target Kafka cluster |
+| STRIMZI_CRUISE_CONTROL_SECRET_NAME     | String  | ""      | Secret name containing the truststore                         |
+| STRIMZI_CRUISE_CONTROL_API_SECRET_NAME | String  | ""      | Secret name containing the API credentials                    |
+
+With Cluster Operator deployment, a dedicated admin user is automatically created for the Topic Operator.
+With standalone deployment, the Cluster Operator expects two secrets that needs to be created by the user:
+
+- A secret with `cruise-control.p12` key containing the truststore in PKCS12 format, and `cruise-control.password` key containing the truststore password.
+- A secret with `cruise-control.apiToAdminUsername` key containing the API username with admin role, and `cruise-control.apiToAdminPassword` key containing the user password.
+
+### KafkaTopic CRD changes
+
+During the whole replicas change process the KafkaTopic remains in a Ready state.
+A replicas change is executed asynchronously, and takes more than one reconciliation to complete.
+
+A new optional KafkaTopicStatus subsection called `replicasChange` is used to update the user, and keep track of the replicas change state.
+At any given time, the replicas change can be pending, ongoing, or completed.
+
+- **Pending**: Not in Cruise Control's task queue (not yet sent or request error).
+  ```sh
+  status:
+    conditions:
+    - lastTransitionTime: "2024-01-18T16:13:50.490918232Z"
+      status: "True"
+      type: Ready
+    observedGeneration: 2
+    replicasChange:
+      completed: false
+    topicName: my-topic
+  ```
+
+- **Ongoing**: In Cruise Control's task queue, but execution not started, or not completed.
+  ```sh
+  status:
+    conditions:
+    - lastTransitionTime: "2024-01-18T16:13:53.490918232Z"
+      status: "True"
+      type: Ready
+    observedGeneration: 3
+    replicasChange:
+      completed: false
+      userTaskId: 1aa418ca-53ed-4b93-b0a4-58413c4fc0cb
+    topicName: my-topic
+  ```
+
+- **Completed**: Cruise Control's task execution completed (target replication factor reconciled).
+  ```sh
+  status:
+    conditions:
+    - lastTransitionTime: "2024-01-18T16:13:58.490918232Z"
+      status: "True"
+      type: Ready
+    observedGeneration: 4
+    topicName: my-topic
+  ```
+
+### Reconciliation logic
+
+At runtime, the Topic Operator watches and periodically reconciles the configuration of all managed and unpaused KafkaTopic resources.
+Among the other configurations, the reconciliation logic detects `KafkaTopic.spec.replicas` changes by comparing with the topic replication factor value in Kafka.
+
+A ReplicasChangeClient is used to isolate the logic required to call the Cruise Control REST API from the rest of the reconciliation logic.
+The ReplicasChangeClient supports sending multiple replicas changes at the same time.
+
+On every reconciliation loop, when Cruise Control integration is enabled and replicas changes are detected, the BatchingTopicController uses the ReplicasChangeClient for the following operations:
+
+1. Request pending replicas changes (uses `topic_configuration` endpoint, and returns topics with pending and ongoing changes).
+2. Check ongoing replicas changes (uses `user_tasks` endpoint, and returns topics with completed changes).
+
+The result of these operations is used to update the KafkaTopic status.
+
+### Error handling
+
+When there is an error, the replicas change remains pending or ongoing (no status update), and it is indefinitely retried by the periodic reconciliation.
+All errors are written in the Topic Operator logs, so that the user can verify the reason of a never ending replicas change.
+
+In Cruise Control, there is no way to differentiate between temporary errors (resolve by themself) from permanent errors (require some action).
+For example, the `NotEnoughValidWindowsException` can be raised when Cruise Control has just started and the cluster model is still building, but also when there is a configuration error which prevents broker metrics collection.
+Another example is the `OptimizationFailureException` raised when some hard goal is violated, which can be temporary if the configured network capacity is less than the real network capacity and there is a traffic peak.
+Instead, the `OngoingExecutionException` is clearly temporary and it means that there is already a task that is being executed by Cruise Control.
+
+Cruise Control allows to scale down the replication factor under the `min.insync.replicas` value, and this can cause disruption to producers with `acks=all`.
+When this happens, the Topic Operator logs a warning but continues with the replicas change, because the KafkaRoller ignores topics with RF < minISR, and they don't event show up as under replicated.
+The target replication factor should also be less than or equal to the number of available brokers, but this is enforced directly by Cruise Control.
+
+When a manged KafkaTopic with replicas change is deleted in Kubernetes, the Topic Operator also deletes the topic in Kafka, but the task execution continues in Cruise Control.
+There is little benefit in using the `stop_proposal_execution` endpoint, because most replicas change tasks will have only one batch that can't be stopped.
+
+When a manged topic with replicas change is deleted in Kafka, the Topic Operator recreates the topic with the target replication factor.
+
+When Topic Operator is restarted, both pending and ongoing replicas changes are recovered from KafkaTopic status.
+The ongoing state includes the `userTaskId`, which is the unique identifier of a Cruise Control task, which includes one or more replicas changes.
+
+When Cruise Control is restarted, all active tasks are lost, as there is no persistent memory.
+The Topic Operator detects this event when the ongoing replicas changes check returns no tasks for a known `userTaskId`.
+All pending and ongoing replicas changes are still stored in KafkaTopic status, and can be recovered as soon as Cruise Control becomes Ready.
+
+## Affected/not affected projects
+
+The following components will be affected by this proposal:
+
+- Topic Operator: this component will drive the whole replication factor change process.
+- Cluster Operator: this component will be responsible to initialize the Cruise Control environment variables.
+
+## Compatibility
+
+There is no backward compatibility issue for this proposal.
+
+## Rejected alternatives
+
+- Use a ReplicasChangeManager object to drive the replicas change reconciliation, which is notified by the BatchingTopicController. 
+  This makes the implementation way more complicated, as this new object needs to maintain an in-memory cache of ongoing changes.
+
+---

--- a/066-topic-replication-factor-change.md
+++ b/066-topic-replication-factor-change.md
@@ -8,7 +8,7 @@ When the Kafka cluster is healthy and a broker is down, another one can serve th
 A tradeoff is that each topic partition will take up an amount of storage equal to its size times the replication factor value.
 The cluster `default.replication.factor` configuration is used when a new topic is created without specifying the replication factor.
 
-When new messages arrives, they are first written into the operating system's page cache, and then flushed to disk asynchronously.
+When new messages arrive, they are first written into the operating system's page cache, and then flushed to disk asynchronously.
 If the Kafka JVM crashes for whatever reason, recent messages are still in the page cache, and can be flushed by the operating system.
 However, this doesn't protect from data loss when the machine crashes, and this is why enabling topic replication is important.
 To further improve fault tolerance, a rack-aware Kafka cluster can be used to distribute topic replicas evenly across data centers in the same geographic region.
@@ -70,7 +70,7 @@ In order to group multiple changes in the same request to Cruise Control, the To
 This JSON contains a list of replication factor values, each one associated with a regex expression of the form `topic1|topic2|topic3` matching all topics with that target replication factor.
 
 This is useful with bulk replicas change, which can happen in some edge cases.
-A potentially big backlog of messages may be created when the Topic Operator is not running, or there is an issue with Cruise Control or Kafka.
+A potentially big backlog of changes may be created when the Topic Operator is not running, or there is an issue with Cruise Control or Kafka.
 Another example is a GitOps pipeline delivering many replicas changes at the same time to reduce the storage occupation of non-critical topics.
 
 ```sh
@@ -264,7 +264,7 @@ When a managed KafkaTopic with replicas change is deleted in Kubernetes, the Top
 There is little benefit in using the `stop_proposal_execution` endpoint, because most replicas change tasks have only one batch that can't be stopped.
 No task remains hanging, the only problem is that Cruise Control does some unnecessary work executing a batch for a topic that has been deleted.
 
-When a manged topic with replicas change is deleted in Kafka, the Topic Operator will recreate the topic with the target replication factor.
+When a managed topic with replicas change is deleted in Kafka, the Topic Operator will recreate the topic with the target replication factor.
 
 When Topic Operator is restarted, both pending and ongoing replicas changes will be recovered from the KafkaTopic status.
 The ongoing state will include a `sessionId`, which is the unique identifier of a Cruise Control task, which includes one or more replicas changes.

--- a/066-topic-replication-factor-change.md
+++ b/066-topic-replication-factor-change.md
@@ -64,7 +64,7 @@ The [`topic_configuration`](https://github.com/linkedin/cruise-control/wiki/REST
 Once accepted, the replication factor change is put into the Cruise Control's task queue and executed asynchronously.
 
 The two required parameters for this endpoint are `topic` (regular expression to specify subject topics) and `replication_factor` (target replication factor).
-In order to group multiple changes in the same request to Cruise Control, the Topic Operator uses a JSON payload containing topics grouped by their replication factor, which replaces the required parameters.
+In order to group multiple changes in the same request to Cruise Control, the Topic Operator uses a [JSON payload](https://github.com/linkedin/cruise-control/wiki/Change-topic-replication-factor-through-Cruise-Control#instruction) containing topics grouped by their replication factor, which replaces the required parameters.
 
 This is useful with bulk replicas change, which can happen in some edge cases.
 A potentially big backlog of messages may be created when the Topic Operator is not running, or there is an issue with Cruise Control or Kafka.

--- a/066-topic-replication-factor-change.md
+++ b/066-topic-replication-factor-change.md
@@ -64,7 +64,8 @@ The [`topic_configuration`](https://github.com/linkedin/cruise-control/wiki/REST
 Once accepted, the replication factor change is put into the Cruise Control's task queue and executed asynchronously.
 
 The two required parameters for this endpoint are `topic` (regular expression to specify subject topics) and `replication_factor` (target replication factor).
-In order to group multiple changes in the same request to Cruise Control, the Topic Operator uses a [JSON payload](https://github.com/linkedin/cruise-control/wiki/Change-topic-replication-factor-through-Cruise-Control#instruction) containing topics grouped by their replication factor, which replaces the required parameters.
+In order to group multiple changes in the same request to Cruise Control, the Topic Operator uses a [JSON payload](https://github.com/linkedin/cruise-control/wiki/Change-topic-replication-factor-through-Cruise-Control#instruction), which replaces the required parameters.
+This JSON contains a list of replication factor values, each one associated with a regex expression of the form `topic1|topic2|topic3` matching all topics with that target replication factor.
 
 This is useful with bulk replicas change, which can happen in some edge cases.
 A potentially big backlog of messages may be created when the Topic Operator is not running, or there is an issue with Cruise Control or Kafka.

--- a/066-topic-replication-factor-change.md
+++ b/066-topic-replication-factor-change.md
@@ -166,7 +166,7 @@ A replicas change is executed asynchronously, and takes more than one reconcilia
 
 A new optional KafkaTopicStatus subsection called `replicasChange` is used to update the user, and keep track of the replicas change state.
 The `replicasChange` can be in a pending or ongoing `state`, and it can contains a `message` in case of failure.
-Other fields are `sessionId`, which maps to Cruise Control's `User-Task-ID`, and `replicas`, which reflects the target replicas value (this may be different from .spec.replicas when the state is ongoing).
+Other fields are `sessionId`, which maps to Cruise Control's `User-Task-ID`, and `targetReplicas`, which reflects the target replicas value (this may be different from .spec.replicas when the state is ongoing).
 
 - **Pending**: Not in Cruise Control's task queue (not yet sent or request error).
   Cruise Control's task states: None.
@@ -178,8 +178,8 @@ Other fields are `sessionId`, which maps to Cruise Control's `User-Task-ID`, and
       type: Ready
     observedGeneration: 2
     replicasChange:
-      replicas: 2
       state: pending
+      targetReplicas: 2
     topicName: my-topic
   ```
 
@@ -193,9 +193,9 @@ Other fields are `sessionId`, which maps to Cruise Control's `User-Task-ID`, and
       type: Ready
     observedGeneration: 3
     replicasChange:
-      replicas: 2
       sessionId: 1aa418ca-53ed-4b93-b0a4-58413c4fc0cb
       state: ongoing
+      targetReplicas: 2
     topicName: my-topic
   ```
 
@@ -222,8 +222,8 @@ Other fields are `sessionId`, which maps to Cruise Control's `User-Task-ID`, and
     observedGeneration: 4
     replicasChange:
       message: Change request failed, Cluster model not ready
-      replicas: 2
       state: pending
+      targetReplicas: 2
     topicName: my-topic
   ```
 

--- a/066-topic-replication-factor-change.md
+++ b/066-topic-replication-factor-change.md
@@ -115,7 +115,7 @@ $ curl -vv -X POST -H "Content-Type: application/json" -d '{replication_factor:{
 ```
 
 The `skip_rack_awareness_check` parameter configures whether to skip the rack awareness sanity check or not (default to false).
-In case of a single-rack deployment, the Topic Operator automatically enables `skip_rack_awareness_check` to allow replication factor changes.
+If rack awareness is not enabled in Strimzi, the `skip_rack_awareness_check` will be set to true.
 
 The `goals` parameter is a comma separated list of goals used to generate the automatic cluster rebalance for the replication factor change.
 This is configurable for all endpoints in `Kafka.spec.cruiseControl.config` using the `default.goals` property.
@@ -275,10 +275,16 @@ All pending and ongoing replicas changes will still be stored in KafkaTopic stat
 
 ## Affected/not affected projects
 
-The following components will be affected by this proposal:
+### Topic Operator
 
-- Topic Operator: this component will drive the whole replication factor change process.
-- Cluster Operator: this component will be responsible to initialize the Cruise Control environment variables.
+This component will drive the whole replication factor change process.
+The Cruise Control integration logic will be isolated in a new ReplicasChangeClient object.
+
+### Cluster Operator
+
+This component will be responsible to generate a new Cruise Control admin user for the Topic Operator, and initialize the environment variables, and mount the Cruise Control API secret.
+The Cruise Control component will be reconciled just before the Entity Operator, so that the Cruise Control API secret will be available when the Entity Operator pod starts.
+When Cruise Control integration is enabled, the Entity Operator reconciler will detect any Cruise Control API secret change, and restart the Entity Operator pod to load the new API credentials.
 
 ## Compatibility
 

--- a/066-topic-replication-factor-change.md
+++ b/066-topic-replication-factor-change.md
@@ -147,22 +147,17 @@ $ curl -s "localhost:9090/kafkacruisecontrol/user_tasks?user_task_ids=5344ca89-3
 The Topic Operator needs to authenticate and send HTTP requests to the Cruise Control's REST API.
 The following environment variables are set by the Cluster Operator for consumption by the Topic Operator when Cruise Control is configured in Kafka resource, or manually by the user in case of standalone deployment:
 
-| Name                                   | Type    | Default | Description                                                   |
-|:---------------------------------------|---------|---------|---------------------------------------------------------------|
-| STRIMZI_CRUISE_CONTROL_ENABLED         | Boolean | false   | Whether Cruise Control integration is enabled                 |
-| STRIMZI_CRUISE_CONTROL_HOSTNAME        | String  | ""      | Cruise Control hostname                                       |
-| STRIMZI_CRUISE_CONTROL_PORT            | Integer | 9090    | Cruise Control port                                           |
-| STRIMZI_CRUISE_CONTROL_SSL_ENABLED     | Boolean | false   | Whether SSL encryption is enabled                             |
-| STRIMZI_CRUISE_CONTROL_AUTH_ENABLED    | Boolean | false   | Whether Basic authentication is enabled                       |
-| STRIMZI_CRUISE_CONTROL_RACK_ENABLED    | Boolean | false   | Whether rack awareness is enabled in the target Kafka cluster |
-| STRIMZI_CRUISE_CONTROL_SECRET_NAME     | String  | ""      | Secret name containing the truststore                         |
-| STRIMZI_CRUISE_CONTROL_API_SECRET_NAME | String  | ""      | Secret name containing the API credentials                    |
+| Name                                  | Type    | Default | Description                                                   |
+|:--------------------------------------|---------|---------|---------------------------------------------------------------|
+| STRIMZI_CRUISE_CONTROL_ENABLED        | Boolean | false   | Whether Cruise Control integration is enabled                 |
+| STRIMZI_CRUISE_CONTROL_RACK_ENABLED   | Boolean | false   | Whether rack awareness is enabled in the target Kafka cluster |
+| STRIMZI_CRUISE_CONTROL_HOSTNAME       | String  | ""      | Cruise Control hostname                                       |
+| STRIMZI_CRUISE_CONTROL_PORT           | Integer | 9090    | Cruise Control port                                           |
+| STRIMZI_CRUISE_CONTROL_SSL_ENABLED    | Boolean | false   | Whether SSL encryption is enabled                             |
+| STRIMZI_CRUISE_CONTROL_AUTH_ENABLED   | Boolean | false   | Whether Basic authentication is enabled                       |
 
-With Cluster Operator deployment, a dedicated admin user is automatically created for the Topic Operator.
-With standalone deployment, the Cluster Operator expects two secrets that needs to be created by the user:
-
-- A secret with `cruise-control.p12` key containing the truststore in PKCS12 format, and `cruise-control.password` key containing the truststore password.
-- A secret with `cruise-control.apiToAdminUsername` key containing the API username with admin role, and `cruise-control.apiToAdminPassword` key containing the user password.
+With the Cluster Operator deployment, the certificate chain in PEM format and the admin user credentials for the Cruise Control REST API are automatically mounted in the Topic Operator container.
+Instead, with the standalone deployment, the user has to mount the certificate chain under `/etc/tls-sidecar/cluster-ca-certs/ca.crt`, and credentials under `/etc/eto-cc-api/cruise-control.apiToAdminUsername` and `/etc/eto-cc-api/cruise-control.apiToAdminPassword`.
 
 ### KafkaTopic CRD changes
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository list of proposals for the Strimzi project. A template for new pr
 
 |  #  | Title                                                                 |
 | :-: |:----------------------------------------------------------------------|
+| 66  | [Topic replication factor change](./066-topic-replication-factor-change.md) |
 | 65  | [Support custom tiered storage plugins](./065-support-tiered-storage.md) |
 | 64  | [Prometheus Metrics Reporter](./064-prometheus-metrics-reporter.md) |
 | 63  | [Pod Disruption Budget Generation Environment Variable](./063-pdb-generation-environment-variable.md) |


### PR DESCRIPTION
Proposal to enable the topic replication factor change directly from KafkaTopic resource when Cruise Control integration is enabled

There is also a [draft implementation](https://github.com/strimzi/strimzi-kafka-operator/pull/9483).