### PR TITLE
Add support for broker demotion

### DIFF
--- a/128-broker-demotion-support.md
+++ b/128-broker-demotion-support.md
@@ -107,6 +107,7 @@ If any of the broker IDs are invalid, the demotion request will be rejected and 
 
 * If a target broker fails while leadership is being transferred to it, all demotion operations involving that broker are aborted, and the source brokers remain the leaders for the affected partitions.
 In this case, the overall demotion request continues on a best-effort basis with the remaining proposed operations, transferring the leadership on brokers that are available.
+Also, a warning listing the affected demoted brokers that still host leader partitions will be added to the `KafkaRebalance` status.
 
 * The following `KafkaRebalance` resource configuration fields are incompatible with, or no-ops for, broker demotion. 
 If any of these fields are specified, the rebalance request will be rejected, an error will be logged by the Strimzi Operator, and an error will be added to the KafkaRebalance status.

--- a/128-broker-demotion-support.md
+++ b/128-broker-demotion-support.md
@@ -1,0 +1,225 @@
+# Broker demotion support via KafkaRebalance resource
+
+This proposal extends the `KafkaRebalance` custom resource to support broker demotion by integrating with Cruise Control's `/demote_broker` endpoint. 
+This would allow users to demote brokers, removing them from partition leadership eligibility, in preparation for maintenance, decommissioning, or other operational needs.
+
+## Current situation
+
+Currently, Strimzi's Cruise Control integration provides several [rebalancing modes](https://strimzi.io/docs/operators/latest/deploying#con-optimization-proposals-modes-str) through the `KafkaRebalance` custom resource:
+* `full`: performs a complete cluster rebalance across all brokers
+* `add-brokers`: moves replicas to newly added brokers after scaling up
+* `remove-brokers`: moves replicas off brokers before scaling down
+* `remove-disks`: performs intra-broker disk rebalancing for JBOD configurations
+
+However, there is no built-in way to demote brokers, which would remove them from partition leadership without moving replicas. 
+When preparing brokers for removal or maintenance, users must rely on the `remove-brokers` mode which moves all partition replicas off the target brokers. 
+This is more disruptive than necessary if the goal is simply to ensure the brokers are not serving as partition leaders.
+
+Cruise Control provides a dedicated [`/demote_broker`](https://github.com/linkedin/cruise-control/wiki/REST-APIs#demote-a-list-of-brokers-from-the-kafka-cluster) endpoint specifically for this use case, but Strimzi does not currently expose it.
+
+## Motivation
+
+There are a few scenarios where demoting brokers without moving replicas is beneficial:
+
+1. **Broker maintenance**: Before performing maintenance on a broker such as upgrading, patching, or restarting, operators may want to transfer leadership away to minimize impact on client traffic, while keeping the broker as a follower to maintain replication factor and availability.
+
+2. **Staged decommissioning**: In a multi-step decommissioning process, operators may first demote brokers to observe the impact on leadership distribution and client performance before committing to fully removing replicas with the `remove-brokers` mode.
+
+3. **Performance isolation**: Operators may want to reduce load on specific brokers experiencing performance issues by removing their leadership responsibilities while keeping them as followers until the issue is diagnosed and resolved.
+
+The `remove-brokers` mode is too aggressive for these scenarios because it moves all replicas off the target brokers resulting in:
+- Significant network bandwidth consumption from replica movement
+- Increased CPU and disk I/O on source and destination brokers
+- Extended time to complete the operation
+- Temporary reduction in replication factor during replica migration
+- Unnecessary disruption when the goal is only to remove leadership
+
+Broker demotion addresses these concerns by only transferring leadership, which is a lightweight operation compared to replica movement.
+
+## Proposal
+
+The proposal is to add a new `demote-brokers` mode to the existing `KafkaRebalance` custom resource, following the same pattern established by the `add-brokers` and `remove-brokers` modes introduced in [proposal 035](https://github.com/strimzi/proposals/blob/main/035-rebalance-types-scaling-brokers.md).
+
+When `spec.mode` is set to `demote-brokers` in the `KafkaRebalance` resource, paritition leadership is moved off the specified brokers while replicas remain in place.
+
+Users must provide a list of broker IDs to demote for broker-level demotion via the `spec.brokers` field.
+
+A `KafkaRebalance` custom resource for broker demotion would look like this:
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaRebalance
+metadata:
+  name: demote-brokers-example
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  mode: demote-brokers
+  brokers:
+    - 3
+    - 4
+```
+
+This example would demote brokers 3 and 4, transferring all partition leadership away from them while keeping the replicas in place.
+
+### Supported parameters for `demote-broker` mode
+
+The supported parameters, new and old, for `demote-brokers` mode in the `KafkaRebalance` resource spec are as follows:
+
+| Field                            | Type    | Description                                                                
+|----------------------------------|---------|-----------------------------------------------------------------------------|
+| brokers                          | integer array    | List of ids of broker to be demoted in the cluster.                |
+| concurrentLeaderMovements        | integer | Upper bound of ongoing leadership movements. Default is 1000.               |
+| skipUrpDemotion                  | boolean | Whether to skip demoting leader replicas for under-replicated partitions.   |
+| excludeFollowerDemotion          | boolean | Whether to skip demoting follower replicas on the broker to be demoted.     |
+| excludeRecentlyDemotedBrokers    | boolean | Whether to allow leader replicas to be moved to recently demoted brokers.   |
+| replicaMovementStrategies        | string array | A list of strategy class names used to determine the execution order for replica position swaps within partitions (metadata changes only, no data movement) in the generated optimization proposal. By default BaseReplicaMovementStrategy is used, which will execute the replica position swaps in the order in which they are generated. |
+| replicationThrottle             | integer | The upper bound, in bytes per second, on the bandwidth used to move replicas. There is no limit by default. |
+
+**NOTE**: As part of this proposal, we will also add a `excludeRecentlyDemotedBrokers` parameter for the `full`, `add-brokers`, and `remove-brokers` KafkaRebalance modes to give users the ability to prevent to leader replicas to be moved to recently demoted brokers.
+When `excludeRecentlyDemotedBrokers` is set to `true`, a broker is considered demoted for the duration specified by the Cruise Control `demotion.history.retention.time.ms` server configuration.
+By default, this value is 1209600000 milleseconds (14 days) but is configurable in the `spec.cruiseControl.config` section of the `Kafka` custom resource.
+
+### User workflow
+
+The workflow for using broker demotion follows the same pattern as other rebalance modes:
+
+1. User creates a `KafkaRebalance` custom resource with `spec.mode: demote-brokers` and specifies the target broker IDs in `spec.brokers`.
+
+2. The `KafkaRebalanceAssemblyOperator` requests an optimization proposal from Cruise Control via the `/demote_broker` endpoint with `dryrun=true`.
+
+3. The operator transitions the `KafkaRebalance` resource to the `ProposalReady` state. 
+The proposal is stored in `status.optimizationResult` and shows which partition leadership transfers will occur.
+
+4. User reviews the proposal and approves it by annotating the resource with `strimzi.io/rebalance=approve`.
+
+5. The operator executes the broker demotion via the `/demote_broker` endpoint with `dryrun=false`.
+
+6. When complete, the operator transitions the `KafkaRebalance` resource to `Ready` state.
+
+### Validation and constraints
+
+The implementation includes the following validation:
+
+* When `demote-brokers` mode is specified, the `brokers` parameter must be provided.
+If the field is missing or empty, the operator will reject the rebalance request and report an error in the `KafkaRebalance` status.
+
+* The specified broker IDs in the `brokers` list must exist in the cluster. 
+If any of the broker IDs are invalid, the demotion request will be rejected and the error will be reported in the `KafkaRebalance` status.
+
+* When an impossible demotion operation is requested for example demoting all brokers or transfering leadship from the only in-sync replica when the KafkaRebalance `spec.skipUrpDemotion` configuration is set to `false`, the demotion request will be rejected and the error will be reported in the `KafkaRebalance` status.
+
+* The following `KafkaRebalance` resource configuration fields are incompatible with broker demotion and if specified, will cause the rebalance to be rejected, an error to logged by the Strimzi Operator, and an errorto be added to the `KafkaRebalance` status:
+  * `goals`
+  * `skipHardGoalCheck`
+  * `rebalanceDisk`
+  * `excludedTopics`
+  * `concurrentPartitionMovementsPerBroker`
+  * `concurrentIntraBrokerPartitionMovements`
+  * `moveReplicasOffVolumes`
+
+### Interaction with other rebalance modes
+
+Broker demotion is independent of other rebalance modes:
+
+* **After demotion**: If decommissioning is the end goal, users can subsequently create a `remove-brokers` rebalance to move replicas off of targeted brokers.
+
+* **Before scaling down**: Demotion can be performed before a `remove-brokers` operation as a preparatory step to minimize disruption.
+
+* **With auto-rebalancing upon scaling**: To reduce the complexity of this proposal, broker demotion will remain as a manual operation independent of cluster scaling as described in [proposal 078](https://github.com/strimzi/proposals/blob/main/078-auto-rebalancing-cluster-scaling.md).
+ 
+* **With standard rebalancing**: After demoting brokers, users can run a `full` mode rebalance to redistribute leadership across the remaining leader-eligible brokers.
+
+## Affected/not affected projects
+
+This proposal affects only the Strimzi Cluster Operator.
+
+**Affected components:**
+* `KafkaRebalanceAssemblyOperator`
+* CRD schema for `KafkaRebalance`
+
+**Not affected:**
+* Topic Operator
+* User Operator
+* Entity Operator
+* Kafka Bridge
+* Kafka Connect
+* Kafka MirrorMaker 2
+
+## Compatibility
+
+The proposed changes are fully backward compatible:
+
+* **API compatibility**: Adding a new enum value to `KafkaRebalanceMode` does not break existing resources. 
+Existing `KafkaRebalance` resources using `full`, `add-brokers`, `remove-brokers`, and `remove-disks` modes continue to work unchanged.
+
+* **CRD compatibility**: The `KafkaRebalance` CRD already includes the `mode` and `brokers` fields required for this feature. 
+No structural changes to the CRD schema are needed beyond allowing the new enum value and adding new parameters.
+
+* **Behavioral compatibility**: Existing rebalancing workflows are unaffected. 
+The new mode is opt-in and requires explicit user action.
+
+## Future Improvements
+
+### Add support for disk-level demotion
+
+Since Cruise Control's [`/demote_broker`](https://github.com/linkedin/cruise-control/wiki/REST-APIs#demote-a-list-of-brokers-from-the-kafka-cluster) endpoint includes a parameter for demoting individual disks, `brokerid_and_logdirs`, a logical follow up feature would be to add support for disk-level demotion.
+
+For disk-level demotion, partition leadership is moved off specific disk volumes on selected brokers, while replicas remain on those volumes.
+
+A `KafkaRebalance` custom resource for disk demotion would look like this:
+
+```yaml
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaRebalance
+metadata:
+  name: demote-disks-example
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  mode: demote-disks
+  moveLeadersOffVolumes:
+    - brokerId: 0
+      volumeIds: [1, 2]
+    - brokerId: 1
+      volumeIds: [0, 1]
+```
+
+This example would demote the disk volumes 1 and 2 of brokers 0 and volumes 0 and 1 of broker 1, transferring all partition leadership away from those volumes while keeping the replicas in place.
+
+#### Supported parameters for `demote-disks` mode
+
+In addition to the supported parameters of the `demote-brokers` mode, the `demote-disks` mode in the `KafkaRebalance` resource spec would introduce the following:
+
+| Field                            | Type    | Description
+|----------------------------------|---------|-----------------------------------------------------------------------------|
+| moveLeadersOffVolumes            | [BrokerAndVolumeIds](https://strimzi.io/docs/operators/latest/configuring.html#type-BrokerAndVolumeIds-reference) array | List of broker ID and volume pairs to be demoted in the cluster. |
+
+#### Validation and constraints
+
+The implementation would include the following validation:
+
+* The specified broker and volume IDs in the `moveLeadersOffVolumes` list must exist in the cluster. 
+Cruise Control will validate this and return an error for the `KafkaRebalance` status if invalid broker IDs or volume IDs are provided.
+
+### Add support for broker-level demotion before automatic cluster scaling
+
+A future enhancement could integrate broker-level demotion with automatic cluster scaling as described in [proposal 078](https://github.com/strimzi/proposals/blob/main/078-auto-rebalancing-cluster-scaling.md).
+In such an implementation, brokers scheduled for removal could first be automatically demoted, ensuring that partition leadership is transferred away from those brokers before scaling operations proceed. 
+This would reduce operational overhead and improve safety by minimizing leadership movement during broker removal.
+
+This enhancement would build on the existing auto-rebalancing mechanisms and could be implemented as an optional, configurable step in the cluster scaling process.
+
+## Rejected alternatives
+
+### Alternative 1: Make demotion part of `remove-brokers` mode
+
+Instead of adding a separate mode, enhance the `remove-brokers` mode to support a two-phase operation: first demote to transfer leadership only and then optionally move replicas.
+
+This could be controlled via a new field like `spec.demoteOnly: true`.
+
+**Reasons for rejection:**
+* Overloads the semantics of `remove-brokers`, which are intended for replica removal
+* Makes the `remove-brokers` mode more complex with conditional behavior
+* Reduces clarity for users about what operation is being performed
+* Inconsistent with the design philosophy of having distinct modes for distinct operations
+* A separate mode provides better visibility in status, metrics, and logs about which operation is in progress.

--- a/128-broker-demotion-support.md
+++ b/128-broker-demotion-support.md
@@ -107,7 +107,7 @@ If any of the broker IDs are invalid, the demotion request will be rejected and 
 * When an impossible demotion operation is requested for example demoting all brokers or transferring leadership from the only in-sync replica when the KafkaRebalance `spec.skipUrpDemotion` configuration is set to `false`, the demotion request will be rejected and the error will be reported in the `KafkaRebalance` status.
 
 * If a target broker fails while leadership is being transferred to it, all demotion operations involving that broker are aborted, and the source brokers remain the leaders for the affected partitions.
-In this case, the overall demotion request continues on a best-effort with the proposed operations, transferring the leadership on brokers that are available.
+In this case, the overall demotion request continues on a best-effort basis with with the remaining proposed operations, transferring the leadership on brokers that are available.
 
 * The following `KafkaRebalance` resource configuration fields are incompatible with, or no-ops for, broker demotion. 
 If any of these fields are specified, the rebalance request will be rejected, an error will be logged by the Strimzi Operator, and an error will be added to the KafkaRebalance status.
@@ -125,29 +125,19 @@ If any of these fields are specified, the rebalance request will be rejected, an
 
 Broker demotion is independent of other rebalance modes:
 
-* **After demotion**: If decommissioning is the end goal, users can subsequently create a `remove-brokers` rebalance to move replicas off of targeted brokers.
+* **add-brokers**: After new brokers are added to the cluster, broker demotion could be used to explicitly transfer partition leadership away from existing brokers to accelerate leadership adoption on newly added brokers. 
 
-* **Before scaling down**: Demotion can be performed before a `remove-brokers` operation as a preparatory step to minimize disruption.
+* **remove-brokers**: Before decommissioning or scaling down brokers, broker demotion could be performed as a preparatory step to minimize disruption.
 
-* **With auto-rebalancing upon scaling**: To reduce the complexity of this proposal, broker demotion will remain as a manual operation independent of cluster scaling as described in [proposal 078](https://github.com/strimzi/proposals/blob/main/078-auto-rebalancing-cluster-scaling.md).
- 
-* **With standard rebalancing**: After demoting brokers, users can run a `full` mode rebalance to redistribute leadership across the remaining leader-eligible brokers.
+* **remove-disks**: Since disk-level demotion support is not included as part of this proposal, this interaction is not applicable.
+
+* **full**: After demoting brokers, users could run a `full` mode rebalance to further redistribute leadership across the remaining leader-eligible brokers.
+
+To reduce the complexity of this proposal and its implementation, broker demotion will remain as a manual operation independent of the other rebalance modes and cluster scaling as described in [proposal 078](https://github.com/strimzi/proposals/blob/main/078-auto-rebalancing-cluster-scaling.md).
 
 ## Affected/not affected projects
 
-This proposal affects only the Strimzi Cluster Operator.
-
-**Affected components:**
-* `KafkaRebalanceAssemblyOperator`
-* CRD schema for `KafkaRebalance`
-
-**Not affected:**
-* Topic Operator
-* User Operator
-* Entity Operator
-* Kafka Bridge
-* Kafka Connect
-* Kafka MirrorMaker 2
+This proposal impacts the Strimzi Cluster Operator in places related to the `KafkaRebalanceAssemblyOperator` and the `KafkaRebalance` API.
 
 ## Compatibility
 

--- a/128-broker-demotion-support.md
+++ b/128-broker-demotion-support.md
@@ -1,51 +1,55 @@
 # Broker demotion support via KafkaRebalance resource
 
-This proposal extends the `KafkaRebalance` custom resource to support broker demotion by integrating with Cruise Control's `/demote_broker` endpoint. 
-This would allow users to demote brokers, removing them from partition leadership eligibility, in preparation for maintenance, decommissioning, or other operational needs.
+This proposal extends the `KafkaRebalance` custom resource to support broker and disk-level demotion by integrating with Cruise Control's `/demote_broker` endpoint. 
+This would allow users to demote brokers or disks, removing them from partition leadership eligibility, in preparation for maintenance, decommissioning, or other operational needs.
 
 ## Current situation
 
-Currently, Strimzi's Cruise Control integration provides several [rebalancing modes](https://strimzi.io/docs/operators/latest/deploying#con-optimization-proposals-modes-str) through the `KafkaRebalance` custom resource:
-* `full`: performs a complete cluster rebalance across all brokers
-* `add-brokers`: moves replicas to newly added brokers after scaling up
-* `remove-brokers`: moves replicas off brokers before scaling down
-* `remove-disks`: performs intra-broker disk rebalancing for JBOD configurations
+The `KafkaRebalance` resource currently supports four distinct modes:
+* `full`: Rebalances across all brokers in the cluster.
+* `add-brokers`:  Moves replicas to newly added brokers.
+* `remove-brokers`: Moves replicas out of brokers to be removed.
+* `remove-disks`: Moves replicas off specified JBOD volumes of specified brokers so those volumes can be removed.
 
-However, there is no built-in way to demote brokers, which would remove them from partition leadership without moving replicas. 
-When preparing brokers for removal or maintenance, users must rely on the `remove-brokers` mode which moves all partition replicas off the target brokers. 
-This is more disruptive than necessary if the goal is simply to ensure the brokers are not serving as partition leaders.
+However, there is no built-in way to demote brokers or disks, meaning to remove them from partition leadership without moving replicas.
+When preparing brokers for removal or maintenance, users must rely on the `remove-brokers` mode which moves all partition replicas off the target brokers.
+Similarly, when preparing disks for removal, users must rely on the `remove-disks` mode which moves all partition replicas off the target disks.
+These operations are more disruptive than necessary if the goal is simply to ensure the brokers or disks are not serving as partition leaders.
 
-Cruise Control provides a dedicated [`/demote_broker`](https://github.com/linkedin/cruise-control/wiki/REST-APIs#demote-a-list-of-brokers-from-the-kafka-cluster) endpoint specifically for this use case, but Strimzi does not currently expose it.
+Cruise Control provides a dedicated [`/demote_broker`](https://github.com/linkedin/cruise-control/wiki/REST-APIs#demote-a-list-of-brokers-from-the-kafka-cluster) endpoint specifically for this use case, but Strimzi does not currently expose it via the `KafkaRebalance` resource.
 
 ## Motivation
 
-There are a few scenarios where demoting brokers without moving replicas is beneficial:
+There are a few scenarios where demoting brokers or disks without moving replicas is beneficial:
 
-1. **Broker maintenance**: Before performing maintenance on a broker such as upgrading, patching, or restarting, operators may want to transfer leadership away to minimize impact on client traffic, while keeping the broker as a follower to maintain replication factor and availability.
+1. **Broker or disk maintenance**: Before performing maintenance on a broker such as upgrading, patching, or restarting, operators may want to transfer leadership away to minimize impact on client traffic, while maintaining replication factor and availability.
 
 2. **Staged decommissioning**: In a multi-step decommissioning process, operators may first demote brokers to observe the impact on leadership distribution and client performance before committing to fully removing replicas with the `remove-brokers` mode.
 
-3. **Performance isolation**: Operators may want to reduce load on specific brokers experiencing performance issues by removing their leadership responsibilities while keeping them as followers until the issue is diagnosed and resolved.
+3. **Performance isolation**: Operators may want to reduce load on specific brokers or disks experiencing performance issues by removing their leadership responsibilities while keeping them as followers until the issue is diagnosed and resolved.
 
-The `remove-brokers` mode is too aggressive for these scenarios because it moves all replicas off the target brokers resulting in:
-- Significant network bandwidth consumption from replica movement
-- Increased CPU and disk I/O on source and destination brokers
+The `remove-brokers` and `remove-disks` modes are too aggressive for these scenarios because they move all replicas off the target brokers or disks resulting in:
+- Significant network bandwidth consumption from replica movement (for broker-level operations)
+- Increased CPU and disk I/O on source and destination brokers or disks
 - Extended time to complete the operation
 - Unnecessary disruption when the goal is only to remove leadership
 
-Broker demotion addresses these concerns by only transferring leadership, which is a lightweight operation compared to replica movement.
+Broker demotion addresses these concerns by only transferring leadership, which is a lightweight operation compared to transferring replicas.
 
 ## Proposal
 
-The proposal is to add a new `demote-brokers` mode to the existing `KafkaRebalance` custom resource, following the same pattern established by the `add-brokers` and `remove-brokers` modes introduced in [proposal 035](https://github.com/strimzi/proposals/blob/main/035-rebalance-types-scaling-brokers.md).
+### API Design
 
-When `spec.mode` is set to `demote-brokers` in the `KafkaRebalance` resource, partition leadership is moved off the specified brokers while replicas remain in place.
+The proposal is to add a new `demote-brokers` mode to the existing `KafkaRebalance` custom resource, following the same pattern established by the `add-brokers` and `remove-brokers` modes introduced in  [proposal 035](https://github.com/strimzi/proposals/blob/main/035-rebalance-types-scaling-brokers.md).
+When `spec.mode` is set to `demote-brokers` in the `KafkaRebalance` resource, partition leadership is moved off the specified brokers or disks while replicas remain in place.
 
-Users must provide a list of broker IDs to demote for broker-level demotion via the `spec.brokers` field.
+#### Broker-level demotion
 
-A `KafkaRebalance` custom resource for broker demotion would look like this:
+For broker-level demotion, users can specify a list of broker IDs to demote via the `spec.nodes` field, following the unified targeting mechanism introduced in  [proposal 154](154-kafkarebalance-custom-resource-consolidation.md).
+
+A `KafkaRebalance` custom resource for broker-level demotion would look like this:
 ```yaml
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaRebalance
 metadata:
   name: demote-brokers-example
@@ -53,34 +57,95 @@ metadata:
     strimzi.io/cluster: my-cluster
 spec:
   mode: demote-brokers
-  brokers:
-    - 3
-    - 4
+  nodes:
+    - brokerId: 3
+    - brokerId: 4
+  config:
+    concurrent_leader_movements: 10
 ```
 
 This example would demote brokers 3 and 4, transferring all partition leadership away from them while keeping the replicas in place.
 
-### Supported fields for `demote-broker` mode
+#### Disk-level demotion
 
-The supported fields, new and old, for `demote-brokers` mode in the `KafkaRebalance` resource spec are as follows:
+For disk-level demotion, users can specify a list of volume (disk) IDs to demote via the `spec.nodes` entries following the unified targeting mechanism introduced in  [proposal 154](154-kafkarebalance-custom-resource-consolidation.md).
 
-| Field                            | Type          | Description                                                                 | Default   |
-|----------------------------------|---------------|-----------------------------------------------------------------------------|------------
-| brokers                          | integer array | List of ids of broker to be demoted in the cluster.                         | N/A       |
-| concurrentLeaderMovements        | integer       | Upper bound of ongoing leadership swaps.                                    | 1000      |
-| skipUrpDemotion                  | boolean       | Whether to skip demoting leader replicas for under-replicated partitions.   | true      |
-| excludeFollowerDemotion          | boolean       | Whether to skip demoting follower replicas on the broker to be demoted.     | true      |
-| excludeRecentlyDemotedBrokers    | boolean       | Whether to allow leader replicas to be moved to recently demoted brokers.   | false     |
+A `KafkaRebalance` custom resource for disk-level demotion would look like this:
+```yaml
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaRebalance
+metadata:
+  name: demote-broker-disks-example
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  mode: demote-brokers
+  nodes:
+    - brokerId: 3
+      volumeIds:
+        - 0
+        - 1
+    - brokerId: 4
+      volumeIds:
+        - 2
+  config:
+    concurrent_leader_movements: 10
+```
 
-**NOTE**: As part of this proposal, we will also add a `excludeRecentlyDemotedBrokers` field for the `full`, `add-brokers`, and `remove-brokers` KafkaRebalance modes to give users the ability to prevent to leader replicas to be moved to recently demoted brokers.
-When `excludeRecentlyDemotedBrokers` is set to `true`, a broker is considered demoted for the duration specified by the Cruise Control `demotion.history.retention.time.ms` server configuration.
-By default, this value is 1209600000 milleseconds (14 days) but is configurable in the `spec.cruiseControl.config` section of the `Kafka` custom resource.
+This example would demote leadership for partitions on volumes 0 and 1 of broker 3 and volume 2 of broker 4, while leaving leadership for partitions on other volumes unchanged.
+
+#### Supported fields for `demote-brokers` mode
+
+The supported fields for `demote-brokers` mode in the `KafkaRebalance` resource spec are as follows.
+
+##### Top-level fields
+
+| Field   | Type                     | Description                                                                                                     | Required     |
+|---------|--------------------------|-----------------------------------------------------------------------------------------------------------------|--------------|
+| `mode`  | string                   | Must be set to `demote-brokers`.                                                                                | **required** |
+| `nodes` | list of `RebalanceNode`  | List of brokers to be demoted, each containing a `brokerId` and optionally `volumeIds` for disk-level demotion. | **required** |
+
+**NOTE**: Deprecated top-level fields that map to supported parameters (e.g. `concurrentLeaderMovements` -> `concurrent_leader_movements`, `replicationThrottle` -> `replication_throttle`, `replicaMovementStrategies` -> `replica_movement_strategies`) are converted to their `spec.config` equivalents at the start of reconciliation, following the conversion process defined in [proposal 154](154-kafkarebalance-custom-resource-consolidation.md).
+
+##### Supported parameters
+
+Following the `spec.config` approach from [proposal 154](154-kafkarebalance-custom-resource-consolidation.md), the parameters supported by Cruise Control's [`/demote_broker`](https://github.com/cruise-control-for-kafka/cruise-control/wiki/REST-APIs#demote-a-list-of-brokers-from-the-kafka-cluster) endpoint are passed as key-value pairs in `spec.config`:
+
+| Config Key                          | Description                                                                         | Default   |
+|-------------------------------------|-------------------------------------------------------------------------------------|-----------|
+| `concurrent_leader_movements`       | Upper bound of ongoing leadership movements.                                        | N/A       |
+| `skip_urp_demotion`                 | Whether to skip demoting leader replicas for under-replicated partitions.           | `"true"`  |
+| `exclude_follower_demotion`         | Whether to skip demoting follower replicas on the broker to be demoted.             | `"true"`  |
+| `exclude_recently_demoted_brokers`  | Whether to allow leader replicas to be moved to recently demoted brokers.           | `"false"` |
+| `replica_movement_strategies`       | Replica movement strategy to use.                                                   | N/A       |
+| `replication_throttle`              | Upper bound on bandwidth used to move replicas (bytes/sec).                         | N/A       |
+
+**NOTE**: The `exclude_recently_demoted_brokers` config key is also supported for the `full`, `add-brokers`, and `remove-brokers` KafkaRebalance modes to give users the ability to prevent leader replicas from being moved to recently demoted brokers.
+When `exclude_recently_demoted_brokers` is set to `"true"`, a broker is considered demoted for the duration specified by the Cruise Control `demotion.history.retention.time.ms` server configuration.
+By default, this value is 1209600000 milliseconds (14 days) but is configurable in the `spec.cruiseControl.config` section of the `Kafka` custom resource.
+
+##### Filtered parameters
+
+The following Cruise Control `/demote_broker` parameters are managed by the operator or by `spec.nodes` and are forbidden in `spec.config`, following the same pattern as the filtered parameters in  [proposal 154](154-kafkarebalance-custom-resource-consolidation.md).
+These are enforced using `FORBIDDEN_PREFIXES` and `FORBIDDEN_PREFIX_EXCEPTIONS` constants in `KafkaRebalanceSpec`, following the same pattern used for [`kafka.config`](https://github.com/strimzi/strimzi-kafka-operator/blob/main/api/src/main/java/io/strimzi/api/kafka/model/kafka/KafkaClusterSpec.java#L56-L72) and [`cruiseControl.config`](https://github.com/strimzi/strimzi-kafka-operator/blob/main/api/src/main/java/io/strimzi/api/kafka/model/kafka/cruisecontrol/CruiseControlSpec.java#L46-L50) sections of the `Kafka` resource configuration.
+If any of these parameters are specified in `spec.config`, they are silently removed and a warning is logged (see [Validation Example 2](#validation-examples)).
+
+| Parameter                   | Why it is filtered                                                                                                 |
+|-----------------------------|--------------------------------------------------------------------------------------------------------------------|
+| `brokerid`                  | Managed via `spec.nodes` top-level field (`brokerId`).                                                             |
+| `brokerid_and_logdirs`      | Managed via `spec.nodes` top-level field (`brokerId` + `volumeIds`).                                               |
+| `dryrun`                    | Strimzi controls this via the rebalance state machine. Proposal generation vs. execution are separate states.      |
+| `json`                      | Hardcoded to `true` by Strimzi. Changing this would break response parsing.                                        |
+| `verbose`                   | Changing verbosity could break status reporting.                                                                   |
+| `allow_capacity_estimation` | Managed by the operator.                                                                                           |
+| `reason`                    | Managed by the operator.                                                                                           |
+| `doAs`                      | Not applicable in Strimzi's deployment model.                                                                      |
 
 ### User workflow
 
 The workflow for using broker demotion follows the same pattern as other rebalance modes:
 
-1. User creates a `KafkaRebalance` custom resource with `spec.mode: demote-brokers` and specifies the target broker IDs in `spec.brokers`.
+1. User creates a `KafkaRebalance` custom resource with `spec.mode: demote-brokers` and specifies the target brokers and optionally volumes in `spec.nodes`.
 
 2. The `KafkaRebalanceAssemblyOperator` requests an optimization proposal from Cruise Control via the `/demote_broker` endpoint with `dryrun=true`.
 
@@ -93,33 +158,97 @@ The proposal is stored in `status.optimizationResult` and shows which partition 
 
 6. When complete, the operator transitions the `KafkaRebalance` resource to `Ready` state.
 
-### Validation and constraints
+### Implementation Strategy
 
-The implementation includes the following validation:
+1. **Validation**
 
-* When `demote-brokers` mode is specified, the `brokers` field must be provided.
-If the field is missing or empty, the operator will reject the rebalance request and report an error in the `KafkaRebalance` status.
+    - **Mode-specific operand validation**:
+      - `nodes` is required and non-empty for `demote-brokers` mode.
+      - For `demote-brokers` mode, `volumeIds` on `nodes` entries is optional.
+        When provided, only partitions on the specified volumes are demoted.
+        When omitted, all partitions on the broker are demoted.
+      - Broker-level and disk-level demotion cannot be mixed in a single `KafkaRebalance` resource.
+        All `nodes` entries must either specify `volumeIds` (disk-level) or none must (broker-level).
+      - The specified broker IDs in the `nodes` list must exist in the cluster.
+      - Impossible demotion operations are rejected, for example demoting all brokers or transferring leadership from the only in-sync replica when `skip_urp_demotion` is set to `"false"` in `spec.config`.
+      - If a target broker fails during leadership transfer, demotion operations involving that broker are aborted and the remaining operations continue on a best-effort basis.
+      - The deprecated `brokers` and `moveReplicasOffVolumes` fields are not supported for `demote-brokers` mode.
+        Since `demote-brokers` is a new mode introduced after [proposal 154](154-kafkarebalance-custom-resource-consolidation.md), there are no existing resources to maintain backward compatibility with.
+        Users must use the `nodes` field instead.
 
-* The specified broker IDs in the `brokers` list must exist in the cluster. 
-If any of the broker IDs are invalid, the demotion request will be rejected and the error will be reported in the `KafkaRebalance` status.
+    - **Parameter field validation**:
+      - Deprecated top-level fields (e.g. `concurrentLeaderMovements`, `replicationThrottle`, `replicaMovementStrategies`) are converted to their `spec.config` equivalents following the conversion process defined in [proposal 154](154-kafkarebalance-custom-resource-consolidation.md).
+      - Deprecated top-level fields that are incompatible with, or no-ops for, broker demotion will be rejected by Cruise Control.
+      The following fields are not supported in `demote-brokers` mode as they are not parameters of the Cruise Control [`/demote_broker`](https://github.com/cruise-control-for-kafka/cruise-control/wiki/REST-APIs#demote-a-list-of-brokers-from-the-kafka-cluster) endpoint:
+        - `skipHardGoalCheck`
+        - `rebalanceDisk`
+        - `excludedTopics`
+        - `concurrentPartitionMovementsPerBroker`
+        - `concurrentIntraBrokerPartitionMovements`
+      - Forbidden parameters in `spec.config` are filtered as described in [Filtered parameters](#filtered-parameters).
 
-* When an impossible demotion operation is requested for example demoting all brokers or transferring leadership from the only in-sync replica when the KafkaRebalance `spec.skipUrpDemotion` configuration is set to `false`, the demotion request will be rejected and the error will be reported in the `KafkaRebalance` status.
+    See [Validation Examples](#validation-examples) for how errors are surfaced to users.
 
-* If a target broker fails while leadership is being transferred to it, all demotion operations involving that broker are aborted, and the source brokers remain the leaders for the affected partitions.
-In this case, the overall demotion request continues on a best-effort basis with the remaining proposed operations, transferring the leadership on brokers that are available.
-Also, a warning listing the affected demoted brokers that still host leader partitions will be added to the `KafkaRebalance` status.
+2. **Update examples** to encourage use of new API structure
+   - Ensure the packaged `KafkaRebalance` resource examples are updated to include `demote-brokers` mode examples using `spec.nodes` and `spec.config`.
 
-* The following `KafkaRebalance` resource configuration fields are incompatible with, or no-ops for, broker demotion. 
-If any of these fields are specified, the rebalance request will be rejected, an error will be logged by the Strimzi Operator, and an error will be added to the KafkaRebalance status.
-  * `replicaMovementStrategies`
-  * `goals`
-  * `skipHardGoalCheck`
-  * `rebalanceDisk`
-  * `excludedTopics`
-  * `concurrentPartitionMovementsPerBroker`
-  * `concurrentIntraBrokerPartitionMovements`
-  * `moveReplicasOffVolumes`
-  * `replicationThrottle`
+3. **Update documentation** to document the new `demote-brokers` mode and point to the upstream [Cruise Control REST API Wiki](https://github.com/cruise-control-for-kafka/cruise-control/wiki/REST-APIs) where needed.
+   - Add a table to the documentation mapping supported and unsupported `spec.config` keys for `demote-brokers` mode.
+   - Add examples showing broker-level and disk-level demotion.
+   - Using the `FORBIDDEN_PREFIXES` and `FORBIDDEN_PREFIX_EXCEPTIONS` constants maintained in the `KafkaRebalanceSpec`, generate API documentation listing which upstream Cruise Control fields are unsupported by Strimzi in the same way it is done for [`cruiseControl.config`](https://strimzi.io/docs/operators/latest/configuring#type-CruiseControlSpec-schema-reference) in the `Kafka` resource.
+   
+#### Validation Examples
+
+  1. **Mixing old and new parameter fields (Strimzi converts with warnings)**:
+    - **KafkaRebalance status**: The resource proceeds normally.
+      A warning condition is added if both a deprecated field and its corresponding new field are set, indicating that the deprecated value is being ignored.
+    - **Cluster Operator log**: WARN for each deprecated field used (deprecation notice), and an additional WARN if both old and new field are set (conflict notice, e.g. "Both `concurrentPartitionMovementsPerBroker` and `spec.config[concurrent_partition_movements_per_broker]` are set.
+     Using the value from `spec.config` and ignoring the deprecated field.")
+    - **Cruise Control log**: N/A
+
+  2. **Forbidden config key (Strimzi filters)**:
+    - **KafkaRebalance status**: The resource proceeds normally. 
+      The forbidden key is ignored.
+    - **Cluster Operator log**: WARN "The config key `dryrun` is forbidden because it is managed by the operator.
+      The key has been ignored."
+    - **Cruise Control log**: N/A
+
+  3. **Invalid config value (Cruise Control rejects)**:
+    - **KafkaRebalance status**: `NotReady` condition with CC error message surfaced
+    - **Cluster Operator log**: WARN with CC error response
+    - **Cruise Control log**: Full error / stack trace
+
+  4. **Unknown config key (Cruise Control rejects)**:
+    - **KafkaRebalance status**: `NotReady` with CC error message surfaced.
+    - **Cluster Operator log**: WARN with CC error response
+    - **Cruise Control log**: Full error / stack trace
+
+  5. **Irrelevant operand for mode (Strimzi rejects)**:
+    - **KafkaRebalance status**: `NotReady` with message: "The `nodes` field is not supported in `full` mode.
+      Remove the `nodes` field to proceed."
+    - **Cluster Operator log**: WARN with same message
+    - **Cruise Control log**: N/A
+
+  6. **Missing `nodes` field (Strimzi rejects)**:
+    - **KafkaRebalance status**: `NotReady` with message: "The `nodes` field is required in `demote-brokers` mode."
+    - **Cluster Operator log**: WARN with same message
+    - **Cruise Control log**: N/A
+
+  7. **Invalid broker ID (Strimzi rejects)**:
+    - **KafkaRebalance status**: `NotReady` with message identifying the invalid broker ID
+    - **Cluster Operator log**: WARN with same message
+    - **Cruise Control log**: N/A
+
+  8. **Deprecated targeting field (e.g. "brokers" or "moveReplicasOffVolumes") used with `demote-brokers` (Strimzi rejects)**:
+    - **KafkaRebalance status**: `NotReady` with message: "The `brokers` field is not supported in `demote-brokers` mode. Use the `nodes` field instead."
+    - **Cluster Operator log**: WARN with same message
+    - **Cruise Control log**: N/A
+
+  9. **Mixed broker-level and disk-level demotion in same resource (Strimzi rejects)**:
+    - **KafkaRebalance status**: `NotReady` with message: "Cannot mix broker-level and disk-level demotion. 
+      All `nodes` entries must either specify `volumeIds` or none must."
+    - **Cluster Operator log**: WARN with same message
+    - **Cruise Control log**: N/A
 
 ### Interaction with other rebalance modes
 
@@ -129,7 +258,8 @@ Broker demotion is independent of other rebalance modes but can be used before o
 
 * **remove-brokers**: Before decommissioning or scaling down brokers, broker demotion could be performed as a preparatory step to minimize disruption.
 
-* **remove-disks**: Since disk-level demotion support is not included as part of this proposal, this interaction is not applicable.
+* **remove-disks**: Before removing disks from a broker, disk-level demotion could be performed as a preparatory step to transfer leadership away from
+    partitions on the targeted disks, minimizing disruption before replica movement begins.
 
 * **full**: After demoting brokers, users could run a `full` mode rebalance to further redistribute leadership across the remaining leader-eligible brokers.
 
@@ -146,17 +276,11 @@ The proposed changes are fully backward compatible:
 * **API compatibility**: Adding a new enum value to `KafkaRebalanceMode` does not break existing resources. 
 Existing `KafkaRebalance` resources using `full`, `add-brokers`, `remove-brokers`, and `remove-disks` modes continue to work unchanged.
 
-* **CRD compatibility**: The `KafkaRebalance` CRD already includes the `mode` and `brokers` fields required for this feature. 
-No structural changes to the CRD schema are needed beyond allowing the new enum value and adding new fields.
+* **CRD compatibility**: The `KafkaRebalance` CRD already includes the `mode`, `nodes`, and `config` fields introduced by [proposal 154](154-kafkarebalance-custom-resource-consolidation.md).
+No structural changes to the CRD schema are needed beyond allowing the new `demote-brokers` enum value.
 
 * **Behavioral compatibility**: Existing rebalancing workflows are unaffected. 
 The new mode is opt-in and requires explicit user action.
-
-## Future Improvements
-
-### Add support for disk-level demotion
-
-Since Cruise Control's [`/demote_broker`](https://github.com/linkedin/cruise-control/wiki/REST-APIs#demote-a-list-of-brokers-from-the-kafka-cluster) endpoint includes a parameter for demoting individual disks, `brokerid_and_logdirs`, a logical follow up feature would be to add support for disk-level demotion.
 
 ## Rejected alternatives
 


### PR DESCRIPTION
### Related problem

When preparing to remove or decommission brokers from a Kafka cluster there is currently no built-in way to ensure those brokers are first demoted (no longer eligible to act as partition leaders). This can result in partitions becoming temporarily unavailable or degraded when those brokers are taken offline, especially in clusters with uneven leadership distribution. Having a mechanism to programmatically demote brokers would allow for safer, more predictable operations during maintenance or scaling events.

### Suggested solution

This feature would extend the KafkaRebalance resource to leverage Cruise Control’s `/kafkacruisecontrol/demote_broker` endpoint [1], allowing users to specify a list of brokers to be demoted. This would trigger the migration of partition leadership away from those brokers in preparation for decommissioning or maintenance.

Addresses issue discussed here [2]

[1] https://github.com/linkedin/cruise-control/wiki/REST-APIs#demote-a-list-of-brokers-from-the-kafka-cluster
[2] https://github.com/strimzi/strimzi-kafka-operator/issues/11907