### PR TITLE
Replace in-process ConnectCluster with StrimziConnectCluster

### DIFF
--- a/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
+++ b/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
@@ -29,20 +29,22 @@ Other already mentioned point is that also shrinks the dependency tree and elimi
 
 ## Proposal
 
-### Changes in test-container
+### New repository: strimzi/test-connectors
 
-Add a built-in testing connector to the test-container project so consumers can use it without depending on Kafka Connect libraries.
+Create a new repository under the Strimzi organization [`strimzi/test-connectors`](https://github.com/strimzi/test-connectors) to host Kafka Connect connectors used for testing purposes.
+This repository (i.) own independent release lifecycle (ii.) produces connector JARs as release artifacts and 
+(iii.) can host multiple test connectors in the future (e.g., source and sink connectors with different testing behaviors).
 
 #### StrimziTestingConnector
 
-A source connector (moved from the operators `TestingConnector`) with configurable behavior:
+The initial connector is a source connector (moved from the operators `TestingConnector`) with configurable behavior:
 
 - Configurable startup/shutdown delays (`start.time.ms`, `stop.time.ms`, `task.start.time.ms`, `task.stop.time.ms`)
 - Configurable task poll behavior (`task.poll.time.ms`, `task.poll.records`)
 - Configurable failures (`fail.on.start`, `task.fail.on.start`)
 - Configurable topic and partition count (`topic.name`, `num.partitions`)
 
-This class depends on `connect-api` (with `provided` scope).
+This class depends on `org.apache.kafka:connect-api`.
 
 #### StrimziTestingConnectorConfig
 
@@ -50,36 +52,50 @@ A constants-only class that exposes the connectors configuration keys and class 
 
 ```java
 public final class StrimziTestingConnectorConfig {
-    public static final String CONNECTOR_CLASS_NAME = "io.strimzi.test.container.StrimziTestingConnector";
+    public static final String CONNECTOR_CLASS_NAME = "io.strimzi.test.connectors.StrimziTestingConnector";
     public static final String FAIL_ON_START = "fail.on.start";
     public static final String TASK_FAIL_ON_START = "task.fail.on.start";
     public static final String START_TIME_MS = "start.time.ms";
     public static final String STOP_TIME_MS = "stop.time.ms";
-    // ... 
+    // ...
 }
 ```
 
 This allows consumers (like the operator) to reference connector configuration without adding `connect-api` to their classpath.
 
+### Changes in test-container-images
+
+The built connector JARs from `strimzi/test-connectors` are bundled into the Kafka Connect test container images at build time.
+The JAR is placed at `/opt/kafka/plugins/<name>/` inside the image.
+
+### Changes in test-container
+
 #### StrimziConnectCluster builder addition
 
-A new builder method enables the testing connector:
+Two new builder methods enable testing connectors:
 
 ```java
 public StrimziConnectClusterBuilder withTestingConnector() { }
+public StrimziConnectClusterBuilder withTestingConnector(String name) { }
 ```
 
-When enabled, the connector JAR is automatically built and copied into the container at `/opt/kafka/plugins/strimzi-testing-connector/`, and `plugin.path` is configured accordingly.
+The no-arg overload defaults to the `StrimziTestingConnector` (i.e., source connector).
+The `String name` overload allows selecting a specific connector by name, which supports adding more connectors to `strimzi/test-connectors` in the future (e.g., a sink connector) without changing the builder API.
+
+When enabled, the `plugin.path` is configured to include `/opt/kafka/plugins/<connector-name>/`, where the pre-built connector JAR is already present in the image.
 
 ### Changes in strimzi-kafka-operator
 
-The main changes are removal of `ConnectCluster.java` and `TestingConnector.java`, which would be moved to the test-container.
-With that we would remove `org.apache.kafka:connect-runtime`, `org.apache.kafka:connect-file` and `org.apache.kafka:connect-api` from the operator repo.
-And eventually we update integration test where we replace in-process with new one (i.e., inside test-container).
+These changes happen after the test-connectors repo, test-container-images, and test-container changes are in place:
+
+1. Remove `ConnectCluster.java` and `TestingConnector.java` from the operator.
+2. Remove `org.apache.kafka:connect-runtime`, `org.apache.kafka:connect-file`, and `org.apache.kafka:connect-api` dependencies.
+3. Add a dependency on `strimzi/test-connectors` (just for `StrimziTestingConnectorConfig` and there will be no `connect-api` transitive dependency).
+4. Update `KafkaConnectApiIT` and `KafkaConnectorIT` to use `StrimziConnectCluster` with `.withTestingConnector()`.
 
 ## Compatibility
 
-This adds new public API surface to test-container (`StrimziTestingConnector`, `StrimziTestingConnectorConfig`, and `withTestingConnector()` builder method), but it is strictly opt-in.
+This adds new public API surface to test-container (the `withTestingConnector()` builder method), but it is strictly opt-in.
 The testing connector is only included when the user explicitly calls `.withTestingConnector()` on the builder (i.e., the default behavior of `StrimziConnectCluster` remains unchanged).
 
 On the operator side, the changes are test-only and do not affect any public APIs.
@@ -90,8 +106,23 @@ On the operator side, the changes are test-only and do not affect any public API
 
 The current approach works, but it introduces unnecessary dependencies that have already caused issues with CVEs.
 
+### Build the connector JAR at runtime
+
+An approach where the connector classes are extracted and assembled into a JAR at container startup (inside `containerIsStarting`) was prototyped.
+While functional, this requires hardcoding class file paths or implementing dynamic class matching rules, making it fragile and harder to maintain.
+Pre-building the JAR as part of a proper release lifecycle and bundling it into the image is cleaner.
+
+### Adopt the echo-sink connector
+
+The existing [echo-sink connector](https://github.com/scholzj/echo-sink) could be moved under the Strimzi organization.
+However, it would need delay and failure simulation features added to match the current `TestingConnector` capabilities.
+
+### Embed connector code in test-container
+
+Placing the connector source code directly in the test-container project would require building the connector JAR at runtime, since test-container does not produce container images itself.
+It is cleaner to keep the connector in a separate repository and bundle the pre-built JAR during the test-container-images build process instead.
+
 ### Add connect-api as a compile dependency in test-container
 
-The `StrimziTestingConnector` needs the Connect API to implement the `SourceConnector` interface.
-Making it a compile dependency would force all test-container consumers to pull in the Connect API even if they don't use it.
-Using `provided` scope keeps it optional, and `StrimziTestingConnectorConfig` gives consumers access to configuration constants without the dependency.
+Making `connect-api` a compile dependency would force all test-container consumers to pull in the Connect API even if they don't use it.
+A separate repository avoids this entirely.

--- a/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
+++ b/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
@@ -24,7 +24,7 @@ The operator can use this directly instead of maintaining its own in-process imp
 ## Motivation
 
 The main motivation is that it removes unnecessary dependencies (i.e., three Connect libraries are only used by two test classes).
-And with that it also reduce overall maintenance for us having both in-memory nad container variant.
+And with that it also reduce overall maintenance for us having both in-memory and container variant.
 Other already mentioned point is that also shrinks the dependency tree and eliminates a recurring source of CVE-related upgrade blockers.
 
 ## Proposal
@@ -38,7 +38,7 @@ This repository:
 - Produces connector JARs as release artifacts
 - Can host multiple test connectors in the future (e.g., source and sink connectors with different testing behaviors)
 
-#### StrimziTestSourceConnector
+#### StrimziFaultInjectionSourceConnector
 
 The initial connector is a source connector (moved from the operator's `TestingConnector`) with configurable fault-injection behavior:
 
@@ -49,13 +49,13 @@ The initial connector is a source connector (moved from the operator's `TestingC
 
 This class depends on `org.apache.kafka:connect-api`.
 
-#### StrimziTestSourceConnectorConfig
+#### StrimziFaultInjectionSourceConnectorConfig
 
 A constants-only class that exposes the connector's configuration keys and class name **without** depending on the Kafka Connect API:
 
 ```java
-public final class StrimziTestSourceConnectorConfig {
-    public static final String CONNECTOR_CLASS_NAME = "io.strimzi.test.connectors.StrimziTestSourceConnector";
+public final class StrimziFaultInjectionSourceConnectorConfig {
+    public static final String CONNECTOR_CLASS_NAME = "io.strimzi.test.connectors.StrimziFaultInjectionSourceConnector";
     public static final String FAIL_ON_START = "fail.on.start";
     public static final String TASK_FAIL_ON_START = "task.fail.on.start";
     public static final String START_TIME_MS = "start.time.ms";
@@ -78,13 +78,13 @@ The JAR is placed at `/opt/kafka/plugins/<connector-name>/` inside the image.
 A dedicated builder method for each test connector:
 
 ```java
-public StrimziConnectClusterBuilder withStrimziTestSourceConnector() { }
+public StrimziConnectClusterBuilder withStrimziFaultInjectionSourceConnector() { }
 ```
 
 When a sink test connector is added in the future, a corresponding method is added:
 
 ```java
-public StrimziConnectClusterBuilder withStrimziTestSinkConnector() { }
+public StrimziConnectClusterBuilder withStrimziFaultInjectionSinkConnector() { }
 ```
 
 When enabled, the `plugin.path` is configured to include `/opt/kafka/plugins/<connector-name>/`, where the pre-built connector JAR is already present in the image.
@@ -96,13 +96,13 @@ These changes happen after the test-connectors repo, test-container-images, and 
 
 1. Remove `ConnectCluster.java` and `TestingConnector.java` from the operator.
 2. Remove `org.apache.kafka:connect-runtime`, `org.apache.kafka:connect-file`, and `org.apache.kafka:connect-api` dependencies.
-3. Add a dependency on `strimzi/test-connectors` (just for `StrimziTestSourceConnectorConfig` and there will be no `connect-api` transitive dependency).
-4. Update `KafkaConnectApiIT` and `KafkaConnectorIT` to use `StrimziConnectCluster` with `.withStrimziTestSourceConnector()`.
+3. Add a dependency on `strimzi/test-connectors` (just for `StrimziFaultInjectionSourceConnectorConfig` and there will be no `connect-api` transitive dependency).
+4. Update `KafkaConnectApiIT` and `KafkaConnectorIT` to use `StrimziConnectCluster` with `.withStrimziFaultInjectionSourceConnector()`.
 
 ## Compatibility
 
-This adds new public API surface to test-container (the `withStrimziTestSourceConnector()` builder method), but it is strictly opt-in.
-The testing connector is only included when the user explicitly calls `.withStrimziTestSourceConnector()` on the builder (i.e., the default behavior of `StrimziConnectCluster` remains unchanged).
+This adds new public API surface to test-container (the `withStrimziFaultInjectionSourceConnector()` builder method), but it is strictly opt-in.
+The testing connector is only included when the user explicitly calls `.withStrimziFaultInjectionSourceConnector()` on the builder (i.e., the default behavior of `StrimziConnectCluster` remains unchanged).
 
 On the operator side, the changes are test-only and do not affect any public APIs.
 

--- a/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
+++ b/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
@@ -75,17 +75,20 @@ The JAR is placed at `/opt/kafka/plugins/<connector-name>/` inside the image.
 
 #### StrimziConnectCluster builder addition
 
-Two new builder methods enable testing connectors:
+A dedicated builder method for each test connector:
 
 ```java
-public StrimziConnectClusterBuilder withTestConnector() { }
-public StrimziConnectClusterBuilder withTestConnector(String name) { }
+public StrimziConnectClusterBuilder withStrimziTestSourceConnector() { }
 ```
 
-The no-arg overload defaults to the `StrimziTestSourceConnector`.
-The `String name` overload allows selecting a specific connector by name, which supports adding more connectors to `strimzi/test-connectors` in the future (e.g., a sink connector) without changing the builder API.
+When a sink test connector is added in the future, a corresponding method is added:
+
+```java
+public StrimziConnectClusterBuilder withStrimziTestSinkConnector() { }
+```
 
 When enabled, the `plugin.path` is configured to include `/opt/kafka/plugins/<connector-name>/`, where the pre-built connector JAR is already present in the image.
+If in the future we need to support users plugging in their own custom connectors, a generic `withConnector(String name)` method could be added instead, but for the known set of Strimzi test connectors, dedicated methods are simpler and safer.
 
 ### Changes in strimzi-kafka-operator
 
@@ -94,12 +97,12 @@ These changes happen after the test-connectors repo, test-container-images, and 
 1. Remove `ConnectCluster.java` and `TestingConnector.java` from the operator.
 2. Remove `org.apache.kafka:connect-runtime`, `org.apache.kafka:connect-file`, and `org.apache.kafka:connect-api` dependencies.
 3. Add a dependency on `strimzi/test-connectors` (just for `StrimziTestSourceConnectorConfig` and there will be no `connect-api` transitive dependency).
-4. Update `KafkaConnectApiIT` and `KafkaConnectorIT` to use `StrimziConnectCluster` with `.withTestConnector()`.
+4. Update `KafkaConnectApiIT` and `KafkaConnectorIT` to use `StrimziConnectCluster` with `.withStrimziTestSourceConnector()`.
 
 ## Compatibility
 
-This adds new public API surface to test-container (the `withTestConnector()` builder method), but it is strictly opt-in.
-The testing connector is only included when the user explicitly calls `.withTestConnector()` on the builder (i.e., the default behavior of `StrimziConnectCluster` remains unchanged).
+This adds new public API surface to test-container (the `withStrimziTestSourceConnector()` builder method), but it is strictly opt-in.
+The testing connector is only included when the user explicitly calls `.withStrimziTestSourceConnector()` on the builder (i.e., the default behavior of `StrimziConnectCluster` remains unchanged).
 
 On the operator side, the changes are test-only and do not affect any public APIs.
 

--- a/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
+++ b/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
@@ -14,8 +14,9 @@ These classes require three test-scoped dependencies:
 - `org.apache.kafka:connect-file`
 - `org.apache.kafka:connect-api`
 
-The `connect-runtime` dependency, in particular, pulls in a large transitive dependency tree.
-This has repeatedly caused issues within CVEs (one of them might be https://github.com/strimzi/strimzi-kafka-operator/pull/12494).
+The `connect-runtime` dependency, in particular, pulls in a large transitive dependency tree that includes libraries such as Jetty.
+These transitive dependencies can conflict with the versions used by the operator itself, blocking CVE fixes.
+For example, [updating Jetty to address CVEs](https://github.com/strimzi/strimzi-kafka-operator/pull/12494) was blocked because the operator Jetty upgrade clashed with the version pulled in by `connect-runtime`, and there was no simple override to resolve it.
 
 Since [Strimzi Proposal #91](091-add-connect-to-test-container.md), the test-container project already provides `StrimziConnectCluster`, a containerized Kafka Connect cluster.
 The operator can use this directly instead of maintaining its own in-process implementation.

--- a/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
+++ b/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
@@ -32,12 +32,15 @@ Other already mentioned point is that also shrinks the dependency tree and elimi
 ### New repository: strimzi/test-connectors
 
 Create a new repository under the Strimzi organization [`strimzi/test-connectors`](https://github.com/strimzi/test-connectors) to host Kafka Connect connectors used for testing purposes.
-This repository (i.) own independent release lifecycle (ii.) produces connector JARs as release artifacts and 
-(iii.) can host multiple test connectors in the future (e.g., source and sink connectors with different testing behaviors).
+This repository:
 
-#### StrimziTestingConnector
+- Owns an independent release lifecycle
+- Produces connector JARs as release artifacts
+- Can host multiple test connectors in the future (e.g., source and sink connectors with different testing behaviors)
 
-The initial connector is a source connector (moved from the operators `TestingConnector`) with configurable behavior:
+#### StrimziTestSourceConnector
+
+The initial connector is a source connector (moved from the operator's `TestingConnector`) with configurable fault-injection behavior:
 
 - Configurable startup/shutdown delays (`start.time.ms`, `stop.time.ms`, `task.start.time.ms`, `task.stop.time.ms`)
 - Configurable task poll behavior (`task.poll.time.ms`, `task.poll.records`)
@@ -46,13 +49,13 @@ The initial connector is a source connector (moved from the operators `TestingCo
 
 This class depends on `org.apache.kafka:connect-api`.
 
-#### StrimziTestingConnectorConfig
+#### StrimziTestSourceConnectorConfig
 
-A constants-only class that exposes the connectors configuration keys and class name **without** depending on the Kafka Connect API:
+A constants-only class that exposes the connector's configuration keys and class name **without** depending on the Kafka Connect API:
 
 ```java
-public final class StrimziTestingConnectorConfig {
-    public static final String CONNECTOR_CLASS_NAME = "io.strimzi.test.connectors.StrimziTestingConnector";
+public final class StrimziTestSourceConnectorConfig {
+    public static final String CONNECTOR_CLASS_NAME = "io.strimzi.test.connectors.StrimziTestSourceConnector";
     public static final String FAIL_ON_START = "fail.on.start";
     public static final String TASK_FAIL_ON_START = "task.fail.on.start";
     public static final String START_TIME_MS = "start.time.ms";
@@ -75,11 +78,11 @@ The JAR is placed at `/opt/kafka/plugins/<connector-name>/` inside the image.
 Two new builder methods enable testing connectors:
 
 ```java
-public StrimziConnectClusterBuilder withTestingConnector() { }
-public StrimziConnectClusterBuilder withTestingConnector(String name) { }
+public StrimziConnectClusterBuilder withTestConnector() { }
+public StrimziConnectClusterBuilder withTestConnector(String name) { }
 ```
 
-The no-arg overload defaults to the `StrimziTestingConnector` (i.e., source connector).
+The no-arg overload defaults to the `StrimziTestSourceConnector`.
 The `String name` overload allows selecting a specific connector by name, which supports adding more connectors to `strimzi/test-connectors` in the future (e.g., a sink connector) without changing the builder API.
 
 When enabled, the `plugin.path` is configured to include `/opt/kafka/plugins/<connector-name>/`, where the pre-built connector JAR is already present in the image.
@@ -90,13 +93,13 @@ These changes happen after the test-connectors repo, test-container-images, and 
 
 1. Remove `ConnectCluster.java` and `TestingConnector.java` from the operator.
 2. Remove `org.apache.kafka:connect-runtime`, `org.apache.kafka:connect-file`, and `org.apache.kafka:connect-api` dependencies.
-3. Add a dependency on `strimzi/test-connectors` (just for `StrimziTestingConnectorConfig` and there will be no `connect-api` transitive dependency).
-4. Update `KafkaConnectApiIT` and `KafkaConnectorIT` to use `StrimziConnectCluster` with `.withTestingConnector()`.
+3. Add a dependency on `strimzi/test-connectors` (just for `StrimziTestSourceConnectorConfig` and there will be no `connect-api` transitive dependency).
+4. Update `KafkaConnectApiIT` and `KafkaConnectorIT` to use `StrimziConnectCluster` with `.withTestConnector()`.
 
 ## Compatibility
 
-This adds new public API surface to test-container (the `withTestingConnector()` builder method), but it is strictly opt-in.
-The testing connector is only included when the user explicitly calls `.withTestingConnector()` on the builder (i.e., the default behavior of `StrimziConnectCluster` remains unchanged).
+This adds new public API surface to test-container (the `withTestConnector()` builder method), but it is strictly opt-in.
+The testing connector is only included when the user explicitly calls `.withTestConnector()` on the builder (i.e., the default behavior of `StrimziConnectCluster` remains unchanged).
 
 On the operator side, the changes are test-only and do not affect any public APIs.
 

--- a/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
+++ b/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
@@ -1,0 +1,96 @@
+# Replace in-process ConnectCluster with StrimziConnectCluster
+
+The `strimzi-kafka-operator` integration tests use an in-process `ConnectCluster` class that embeds the Kafka Connect runtime.
+This proposal aims to replace it with the containerized `StrimziConnectCluster` from [test-container](https://github.com/strimzi/test-container), removing three Kafka Connect dependencies from the operator.
+
+## Current situation
+
+The `cluster-operator` module has two test-only classes for Kafka Connect integration testing: 
+(i.) **`ConnectCluster`**, which starts an in-process Kafka Connect cluster using `org.apache.kafka.connect.cli.ConnectDistributed`;
+(ii.) **`TestingConnector`**, a source connector with configurable delays and failures, used by `KafkaConnectApiIT` and `KafkaConnectorIT`.
+
+These classes require three test-scoped dependencies:
+- `org.apache.kafka:connect-runtime`
+- `org.apache.kafka:connect-file`
+- `org.apache.kafka:connect-api`
+
+The `connect-runtime` dependency, in particular, pulls in a large transitive dependency tree.
+This has repeatedly caused issues within CVEs (one of them might be https://github.com/strimzi/strimzi-kafka-operator/pull/12494).
+
+Since [Strimzi Proposal #91](091-add-connect-to-test-container.md), the test-container project already provides `StrimziConnectCluster`, a containerized Kafka Connect cluster.
+The operator can use this directly instead of maintaining its own in-process implementation.
+
+## Motivation
+
+The main motivation is that it removes unnecessary dependencies (i.e., three Connect libraries are only used by two test classes).
+And with that it also reduce overall maintenance for us having both in-memory nad container variant.
+Other already mentioned point is that also shrinks the dependency tree and eliminates a recurring source of CVE-related upgrade blockers.
+
+## Proposal
+
+### Changes in test-container
+
+Add a built-in testing connector to the test-container project so consumers can use it without depending on Kafka Connect libraries.
+
+#### StrimziTestingConnector
+
+A source connector (moved from the operators `TestingConnector`) with configurable behavior:
+
+- Configurable startup/shutdown delays (`start.time.ms`, `stop.time.ms`, `task.start.time.ms`, `task.stop.time.ms`)
+- Configurable task poll behavior (`task.poll.time.ms`, `task.poll.records`)
+- Configurable failures (`fail.on.start`, `task.fail.on.start`)
+- Configurable topic and partition count (`topic.name`, `num.partitions`)
+
+This class depends on `connect-api` (with `provided` scope).
+
+#### StrimziTestingConnectorConfig
+
+A constants-only class that exposes the connectors configuration keys and class name **without** depending on the Kafka Connect API:
+
+```java
+public final class StrimziTestingConnectorConfig {
+    public static final String CONNECTOR_CLASS_NAME = "io.strimzi.test.container.StrimziTestingConnector";
+    public static final String FAIL_ON_START = "fail.on.start";
+    public static final String TASK_FAIL_ON_START = "task.fail.on.start";
+    public static final String START_TIME_MS = "start.time.ms";
+    public static final String STOP_TIME_MS = "stop.time.ms";
+    // ... 
+}
+```
+
+This allows consumers (like the operator) to reference connector configuration without adding `connect-api` to their classpath.
+
+#### StrimziConnectCluster builder addition
+
+A new builder method enables the testing connector:
+
+```java
+public StrimziConnectClusterBuilder withTestingConnector() { }
+```
+
+When enabled, the connector JAR is automatically built and copied into the container at `/opt/kafka/plugins/strimzi-testing-connector/`, and `plugin.path` is configured accordingly.
+
+### Changes in strimzi-kafka-operator
+
+The main changes are removal of `ConnectCluster.java` and `TestingConnector.java`, which would be moved to the test-container.
+With that we would remove `org.apache.kafka:connect-runtime`, `org.apache.kafka:connect-file` and `org.apache.kafka:connect-api` from the operator repo.
+And eventually we update integration test where we replace in-process with new one (i.e., inside test-container).
+
+## Compatibility
+
+This adds new public API surface to test-container (`StrimziTestingConnector`, `StrimziTestingConnectorConfig`, and `withTestingConnector()` builder method), but it is strictly opt-in.
+The testing connector is only included when the user explicitly calls `.withTestingConnector()` on the builder (i.e., the default behavior of `StrimziConnectCluster` remains unchanged).
+
+On the operator side, the changes are test-only and do not affect any public APIs.
+
+## Rejected alternatives
+
+### Keep the in-process ConnectCluster
+
+The current approach works, but it introduces unnecessary dependencies that have already caused issues with CVEs.
+
+### Add connect-api as a compile dependency in test-container
+
+The `StrimziTestingConnector` needs the Connect API to implement the `SourceConnector` interface.
+Making it a compile dependency would force all test-container consumers to pull in the Connect API even if they don't use it.
+Using `provided` scope keeps it optional, and `StrimziTestingConnectorConfig` gives consumers access to configuration constants without the dependency.

--- a/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
+++ b/136-replace-in-process-connect-cluster-with-strimzi-connect-cluster.md
@@ -66,7 +66,7 @@ This allows consumers (like the operator) to reference connector configuration w
 ### Changes in test-container-images
 
 The built connector JARs from `strimzi/test-connectors` are bundled into the Kafka Connect test container images at build time.
-The JAR is placed at `/opt/kafka/plugins/<name>/` inside the image.
+The JAR is placed at `/opt/kafka/plugins/<connector-name>/` inside the image.
 
 ### Changes in test-container
 


### PR DESCRIPTION
This proposal aims to replace it with the containerized `StrimziConnectCluster` from [test-container](https://github.com/strimzi/test-container), removing three Kafka Connect dependencies from the operator.