### PR TITLE
Use custom PR template for proposals

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+### Type of Change
+
+_Select the type of your PR and delete the other items_
+
+- New Proposal
+- Other
+
+### Description
+
+_Please describe your pull request_
+
+### Checklist
+
+_Please go through this checklist and make sure all applicable tasks have been done_
+
+- [ ] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
+- [ ] BEFORE MERGING: The next free sequence number was used for the proposal and all its assets (images, etc.)
+- [ ] BEFORE MERGING: The proposal index in README.md was updated

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /.idea/
+
+# AI assistants configuration
+.claude/
+.mcp.json
+.bob/
+.opencode


### PR DESCRIPTION
### Type of Change

- Other

### Description

The default PR template does not really fit the proposals repository. So this PR adds a custom template for proposals. It also adds various AI assistant local folders to the `.gitignore` file.