### PR TITLE
Add proposal for safe rollout of listener connectivity changes

### DIFF
--- a/148-safe-listener-connectivity-rollout.md
+++ b/148-safe-listener-connectivity-rollout.md
@@ -1,0 +1,275 @@
+# Safe rollout of listener connectivity changes (per-broker listener-resource reconciliation + deterministic node ports)
+
+Make connectivity-affecting listener changes (listener type changes, port changes, adding/removing a listener) safe to roll out and roll back. This applies to **all listener types that provision per-broker Kubernetes resources** — `nodeport`, `loadbalancer`, `cluster-ip`, `route`, and `ingress` — not just `nodeport`. The proposal has two complementary parts:
+
+- **Per-broker listener-resource reconciliation aligned with the rolling update (the general fix).** Reconcile each broker's listener resources (its `Service`, and `Route`/`Ingress` where applicable) in lockstep with that broker's own restart, instead of replacing all per-broker resources for the whole cluster up front while the brokers restart one by one. This removes the availability window — present for **every** per-broker listener type — where a not-yet-rolled broker's resources already point at a listener the broker is not yet serving.
+- **Deterministic node ports (a `nodeport`-specific hardening).** Give `nodeport` listeners stable, formula-derived node ports so deployments and rollbacks never reshuffle ports between listeners. This removes the most severe failure from the incident below (clients hitting the *wrong SASL mechanism*), with a small, low-risk change and no change to the rolling-update machinery.
+
+The two are independent and can ship separately. The rest of this document refers to them as **Phase 1 (deterministic node ports)** and **Phase 2 (per-broker reconciliation)**, numbered by expected delivery order (Phase 1 is the smaller change and is expected to land first), not by importance — Phase 2 is the general fix.
+
+`loadbalancer` listeners have an address-churn problem analogous to the `nodeport` port reshuffle (the cloud may reassign the external IP/hostname when the `Service` is recreated); equivalent pinning mitigations exist but are cloud-provider-specific and are out of scope here. The general remedy for `loadbalancer` (and all other types) is Phase 2.
+
+> **Scope: KRaft only.** This proposal assumes KRaft-based Kafka clusters and does not consider ZooKeeper-based clusters (ZooKeeper support has been removed from current Strimzi). The Phase 2 partial-roll correctness argument relies on KRaft broker-registration semantics (see [KRaft assumption](#kraft-assumption)).
+
+## Current situation
+
+The Kafka reconciliation pipeline reconciles listeners and rolls the pods in two separate, sequential phases:
+
+```java
+// KafkaReconciler.reconcile()
+.compose(i -> listeners())                       // (1) reconcile ALL Services + compute advertised.listeners
+...
+.compose(i -> brokerConfigurationConfigMaps())   // (2) write broker configs (incl. advertised.listeners)
+...
+.compose(i -> podSet())
+.compose(podSetDiffs -> rollingUpdate(podSetDiffs)) // (3) restart pods ONE BY ONE
+```
+
+In phase (1), `listeners()` reconciles the shared bootstrap resources and **every** per-broker listener resource at once. Each external listener provisions per-broker Kubernetes objects — a `Service` for `nodeport`/`loadbalancer`/`cluster-ip`, plus a `Route` (`route`) or `Ingress` (`ingress`) — and they are all reconciled cluster-wide before any pod rolls.
+
+The brokers, however, only pick up the new listener configuration when they restart, which happens **one pod at a time** in phase (3). This gap produces two failure modes.
+
+#### Failure mode A — resource/broker mismatch window (all per-broker listener types)
+
+When the listener **type** changes (for example `nodeport` → `cluster-ip` or a rollback back to `nodeport`), a `port` changes, or a listener is added/removed, all per-broker resources are switched/replaced immediately, but each broker only starts serving the new listener when it restarts. Brokers that have **not yet** restarted still serve the **old** listener, but their resources have **already** been switched. Clients connecting to those brokers fail (connection refused / unreachable / wrong endpoint) for the whole duration of the roll, not just briefly during a restart. This applies to **every** per-broker listener type, regardless of how addresses are assigned.
+
+#### Failure mode B — address churn on resource recreate (`nodeport` and `loadbalancer`)
+
+Some listener types do not have a stable externally-visible address across a resource recreate:
+
+- For `nodeport`, the `spec.ports[].nodePort` is normally assigned randomly by Kubernetes from the service node-port range. `ServiceOperator.patchNodePorts` only preserves it when the current and desired `Service` are **both** already `NodePort` (or both `LoadBalancer`):
+
+```java
+// ServiceOperator.internalUpdate(...)
+if (("NodePort".equals(current.getSpec().getType()) && "NodePort".equals(desired.getSpec().getType()))
+        || ("LoadBalancer".equals(current.getSpec().getType()) && "LoadBalancer".equals(desired.getSpec().getType())))   {
+    patchNodePorts(current, desired);
+```
+
+So across a **type change** the old port cannot be preserved and Kubernetes allocates fresh random ports on the way back to `NodePort`. The severe consequence is **cross-listener collision**: random reallocation can move a port that previously fronted one listener onto a *different* listener, so a client with cached metadata sends, say, a SCRAM handshake to a port now serving the Kerberos listener — a hard authentication-protocol mismatch that does not self-heal.
+
+- For `loadbalancer`, the cloud may assign a new external IP/hostname when the `Service` is recreated, so cached clients target an address that no longer exists.
+
+`cluster-ip`, `route`, and `ingress` addresses are normally derived deterministically from resource names, so they suffer Failure mode A but not B.
+
+### Incident this addresses
+
+A large `nodeport`-based cluster (a few hundred nodes) exposed two SASL listeners (SCRAM and Kerberos) as per-broker `NodePort` services.
+A deployment switched the listeners to `cluster-ip` and was then rolled back to `nodeport`.
+The rollback re-allocated random node ports — some SCRAM ports landed on Kerberos and vice versa — and, because all `Service`s were switched at once while brokers restarted one by one, brokers that had not yet restarted had `Service`s that no longer matched their running listeners.
+Clients holding cached metadata kept hitting the wrong port/mechanism and produced errors such as:
+
+```
+Client SASL mechanism 'SCRAM-SHA-512' not enabled in the server, enabled mechanisms are [GSSAPI]
+Client SASL mechanism 'GSSAPI' not enabled in the server, enabled mechanisms are [SCRAM-SHA-512]
+```
+
+Reads and writes failed cluster-wide for ~3 hours and only recovered after every broker pod was deleted to force a full, consistent reconcile.
+The port collision was the proximate cause of the sustained auth failures; the all-at-once `Service` switch extended the unavailability across the whole roll.
+
+## Motivation
+
+Two independent weaknesses combined into the outage:
+
+- **All per-broker resources switched at once vs. brokers restarting one-by-one** caused the cluster-wide unavailability window (Failure mode A). This is general to every per-broker listener type, not specific to `nodeport`; the same outage shape can occur on a `loadbalancer`, `route`, `ingress`, or `cluster-ip` type change.
+- **Random, type-dependent node ports** caused the cross-listener collision and therefore the auth-mechanism mismatch (Failure mode B) — the part that was severe, sustained, and required a full pod delete to clear. (`loadbalancer` has the analogous IP-churn variant.)
+
+Fixing only the window (without stable ports) still leaves the severe `nodeport` collision on a type change. Fixing only the ports (without coupling) still leaves the availability window for all types. Hence the phased proposal: a general coupling fix for the window across all listener types (Phase 2), plus a cheap `nodeport` hardening that kills the worst symptom (Phase 1).
+
+## Proposal
+
+### Phase 1 — Deterministic node ports
+
+Provide a way to assign every broker (and the bootstrap) of a `nodeport` listener a **stable, deterministic** node port that does not depend on `Service` create/delete ordering or type changes.
+
+Strimzi already supports pinning node ports statically per broker (`configuration.bootstrap.nodePort`, `configuration.brokers[].nodePort`), but enumerating hundreds of brokers across two listeners is impractical and error-prone, and the node IDs must be known up front (awkward with KRaft/node pools). A formula-based template — mirroring the existing `advertisedPortTemplate` (Proposal #135) — removes that limitation, e.g.:
+
+```yaml
+listeners:
+  - name: scram
+    port: 9096
+    type: nodeport
+    tls: true
+    authentication:
+      type: scram-sha-512
+    configuration:
+      nodePortTemplate: 30000 + {nodeId}
+  - name: kerberos
+    port: 9097
+    type: nodeport
+    tls: true
+    configuration:
+      nodePortTemplate: 31000 + {nodeId}
+```
+
+Because each listener maps to a disjoint port range and each broker's port is a pure function of its node ID, ports are identical across every deploy, rollback and type change, and two listeners can never collide. Node-port validation is extended to reject rendered values outside the service node-port range and duplicates within a listener.
+
+Phase 1 requires no change to the rolling update and is fully backwards compatible (explicit per-broker `nodePort` continues to take precedence). It can be delivered and adopted before Phase 2.
+
+### Phase 2 — Per-broker listener-resource reconciliation aligned with the rolling update
+
+This is the general fix and applies to **all per-broker listener types** (`nodeport`, `loadbalancer`, `cluster-ip`, `route`, `ingress`).
+
+When a reconciliation includes a **connectivity-affecting listener change**, reconcile the per-broker listener resources (the broker's `Service`, and its `Route`/`Ingress` where applicable) as part of the rolling update, broker by broker, instead of all at once before the roll. Then, at every instant, each broker's resources match the listener that broker is actually running, and the change rolls through the cluster the same safe way a normal restart does.
+
+A change is "connectivity-affecting" when it changes what a client must connect to:
+
+- a listener's `type` changes;
+- a listener's `port` changes;
+- a listener is added or removed.
+
+All other reconciliations (config-only changes, certificate rotations, image upgrades, scaling, etc.) keep the current behaviour unchanged.
+
+#### Precondition: the internal listeners are never part of the change
+
+The rolling update's safety checks (quorum / in-sync-replica `canRoll`) depend on the operator's admin client, which connects over the **internal** replication and control-plane listeners (the headless `brokers` service on `REPLICATION_PORT` / `CONTROLPLANE_PORT`), not the external listener being changed:
+
+```java
+// KafkaRoller.adminClient(...)
+bootstrapHostnames = nodes.stream().filter(NodeRef::broker)
+    .map(node -> DnsNameGenerator.podDnsNameWithoutClusterDomain(namespace, KafkaResources.brokersServiceName(cluster), node.podName()) + ":" + KafkaCluster.REPLICATION_PORT)
+    .collect(Collectors.joining(","));
+```
+
+This is exactly what makes Phase 2 safe: the external listener can be in flux while the operator still reaches the cluster for availability checks. The coupled path is therefore valid **only for external/client listeners**; a change to the internal replication/control listener cannot use this mechanism and must fall back to the current behaviour (or be disallowed). The detector must guard for this.
+
+#### Per-broker convergence guard (idempotency)
+
+Reconciliations can be interrupted and re-run, leaving the cluster half-migrated (some brokers new, some old). The "connectivity change" decision must therefore be evaluated **per broker** — "do this broker's observed listener resources already match the desired listener config?" — not as a single cluster-global flag. Brokers already at the desired state are skipped, so a re-run resumes the migration instead of re-rolling the whole cluster. This makes the operation convergent and resumable.
+
+#### Per-broker rollout loop
+
+For each broker that is not yet converged, in the order and under the safety gates the existing roll already enforces:
+
+1. Reconcile **that broker's** listener resource(s) — `Service`, and `Route`/`Ingress` where applicable — to the desired state (create/update/delete). For types whose externally-visible address is assigned asynchronously, wait until it is available for that broker: the assigned `nodePort` (`nodeport`, deterministic with Phase 1), the load-balancer ingress IP/hostname (`loadbalancer`), or the admitted host (`route`). `cluster-ip`/`ingress` addresses are deterministic and need no wait.
+2. Render **that broker's** configuration with the resulting `advertised.listeners` and apply its `ConfigMap`.
+3. Restart the broker so it starts serving the new listener and re-registers its advertised endpoint.
+4. Wait until the broker is ready before moving to the next broker.
+
+#### Bootstrap resource
+
+The bootstrap resource is shared (one `Service`/`Route`/`Ingress` for the whole listener) and is reconciled **last**, after all brokers have rolled.
+This avoids switching the shared entry point until the per-broker endpoints behind it are all consistent, and makes the bootstrap change a single, fast operation at the end.
+Note this does **not** guarantee a *reachable* bootstrap throughout the roll: if the bootstrap's current state is itself part of the change (e.g. mid-rollback it is still the wrong type), clients doing a cold start or metadata refresh *through the bootstrap* recover only once it flips at the end. Clients holding cached per-broker metadata are unaffected (see below).
+
+#### Availability during a partial roll
+
+A half-rolled cluster does **not** cause widespread failure for clients with cached metadata; it degrades to an ordinary rolling restart.
+
+For any partition, such a client connects to the leader's currently-advertised address:
+
+- leader on an already-rolled broker → metadata gives the new address, the new resource exists → works;
+- leader on a not-yet-rolled broker → metadata gives the old address, the old resource still exists → works;
+- leader on the broker currently restarting → brief unavailability while leadership fails over to an in-sync replica, covered by normal client retries (RF ≥ 2).
+
+Remaining failure modes are the ordinary ones, not new to this change:
+
+- **RF = 1 topics**: partitions led by the broker currently restarting are unavailable until it returns (true for any restart).
+- **Cold-start / bootstrap-dependent clients**: see the bootstrap note above — they recover when the bootstrap flips at the end.
+- **Momentary stale metadata**: a client that cached a broker's address immediately before that broker rolls gets a single failed connection and recovers on the next metadata refresh.
+
+This is fundamentally different from the current behaviour, where a not-yet-rolled broker's mismatched resources fail *all* connections to it for the *entire* roll.
+
+#### KRaft assumption
+
+The partial-roll correctness argument depends on KRaft semantics and applies to **KRaft-based clusters only**:
+
+- Each broker registers its **own** `advertised.listeners` with the KRaft controller on start-up, and the controller propagates the full set of broker endpoints to all brokers. A broker re-registering a new endpoint when it rolls is therefore enough for the rest of the cluster (and client metadata) to see the change — Strimzi does **not** need to rewrite every broker's configuration up front for the new addresses to become visible. This is what makes incremental per-broker convergence safe.
+- Each broker's advertised address depends only on **that broker's own** resources, so its config can be rendered from its own resources alone, with no cross-broker dependency: for `nodeport` the advertised host is resolved by the pod from its scheduled node (via an env var) and only the port comes from the broker's `Service`; for `loadbalancer` the address comes from that broker's LB `Service` ingress; for `cluster-ip` from its per-broker DNS name; for `route`/`ingress` from that broker's `Route`/`Ingress` host.
+- Controller-only KRaft nodes have no client listeners and are skipped by the per-broker resource/config steps.
+
+ZooKeeper-based clusters are explicitly out of scope.
+
+### Implementation sketch (Phase 2)
+
+The change is an ordering/wiring change in the Cluster Operator; the building blocks already exist.
+
+**1. Detect connectivity change, per broker.**
+Before the roll, for each broker compare the desired listener config against the observed per-broker resources to compute whether that broker needs a coupled reconcile. If no broker needs one, the reconciliation keeps the **current** behaviour exactly (`listeners()` → `perBrokerKafkaConfiguration()` → `podSet()` → `rollingUpdate()`). The new path is taken only for connectivity changes on external listeners (per the precondition above).
+
+**2. Split `KafkaListenersReconciler.reconcile()` into reusable pieces.**
+Today it reconciles bootstrap + all per-broker resources and returns one `ReconciliationResult` (with `advertisedHostnames` / `advertisedPorts`, both `Map<Integer, Map<String, String>>`). Factor out:
+
+- `reconcileSharedPrerequisites()` — listener `Secret`s/certificates and other non-connectivity, non-bootstrap resources.
+- `reconcileBrokerListener(NodeRef)` — reconcile **one** broker's per-broker resources (`Service`, and `Route`/`Ingress` where applicable), wait for that broker's asynchronously-assigned address where relevant (`nodePort` / LB ingress / route host), and return that broker's `advertisedHostnames` / `advertisedPorts` entries. This generalizes the existing per-listener-type readiness steps (`nodePortServicesReady`, `loadBalancerServicesReady`, `routesReady`, …) to operate on a single broker.
+- `reconcileBootstrap()` — the shared bootstrap resource (`Service`/`Route`/`Ingress`) and final listener status.
+
+**3. Drive the per-broker resource reconcile from the exact pre-restart moment.**
+The roll iterates node by node on a single-threaded executor via `maybeRollKafka(...)` → `KafkaRoller`. A node can be *considered* many times and deferred (`UnforceableProblem` + backoff) when `canRoll` fails, so the only correct place to switch a broker's resources is **immediately before the pod is actually deleted** — i.e. right before each `restartAndAwaitReadiness(...)` call, *after* the availability gate has passed. There are three such call sites in `restartIfNecessary(...)`:
+
+- the `forceRestart` branch (used for stuck/unresponsive/old-revision pods — *not* the connectivity-change path, which is `needsRestart`);
+- the normal `needsRestart`/`needsReconfig` branch, reached only after `canRoll(...)` returns true;
+- the force-roll-on-error fallback, reached only after `canRoll(..., true, ...)` returns true.
+
+The hook (`reconcileBrokerListener(node)` + that broker's `ConfigMap` update) must:
+
+- fire only at those points, never when a node is merely "considered" (otherwise the broker's resources are switched while the still-running broker serves the old listener — the exact bug, localized to one broker for the duration of a deferral);
+- be **idempotent**, because a node may pass `canRoll` and still be retried.
+
+A connectivity change is signalled by `podNeedsRestart` returning a new reason (e.g. `LISTENER_CONFIGURATION_CHANGE`) for brokers that are not yet converged. This yields `needsRestart = true` (so it is gated by `canRoll` and never the unsafe `forceRestart`) and short-circuits the dynamic-reconfiguration path (`advertised.listeners` is not dynamically updatable anyway).
+
+**4. Avoid the PodSet "double-roll".**
+The advertised host/port hash is folded into the broker config hash and surfaced as a **pod annotation** (`perBrokerKafkaConfiguration()` → `podSetPodAnnotations()`), and `podSet()` runs *before* the roll and can itself restart pods when annotations change. If the new advertised config were applied up front, `podSet()` would roll pods prematurely — with the new annotation but before the per-broker `Service` hook runs. Phase 2 must therefore keep the up-front `podSet()` carrying the **old** advertised hash and apply each broker's new config/annotation during the roll (step 3), so a broker is rolled exactly once, by `KafkaRoller`, with its `Service` already switched. This is the most delicate part of the implementation and must be covered by tests.
+
+**5. Reconcile the bootstrap last**, then populate listener status.
+
+Resulting high-level flow in `KafkaReconciler.reconcile()` for a connectivity-affecting change:
+
+```text
+reconcileSharedPrerequisites()        // certs/secrets, no connectivity change
+  -> podSet()                         // non-connectivity pod changes only; OLD advertised hash
+  -> coupledListenerRollingUpdate()   // maybeRollKafka; for each not-yet-converged broker,
+                                      // at the pre-restartAndAwaitReadiness point (post canRoll):
+       reconcileBrokerListener(broker)    // that broker's Service/Route/Ingress + wait for assigned address
+       update that broker's ConfigMap     // advertised.listeners + annotation for this broker
+       restart broker                     // serves new listener, re-registers endpoint
+       wait until ready
+  -> reconcileBootstrap()             // shared bootstrap resource switched once, at the end
+  -> listener status
+```
+
+**Edge cases / notes.**
+
+- If a broker fails to roll, the bootstrap is never switched; the cluster is left in a still-functional mixed state (each broker self-consistent) and the next reconcile resumes via the per-broker convergence guard.
+- `KafkaRoller`'s existing controller/quorum and in-sync-replica safety checks are unchanged and continue to gate each broker's restart.
+
+### Implementation alternative considered for Phase 2
+
+Rather than teaching `KafkaRoller` to reconcile listener resources, the listener reconciler could drive the roll itself by calling `maybeRollKafka(...)` with a **single-node set per broker**, reconciling that broker's resources between calls. This keeps resource/`ConfigMap` I/O out of `KafkaRoller` and preserves its clean "pods + admin client only" boundary, which is attractive for the operator's most safety-critical component.
+
+The downside is real: a fresh `KafkaRoller` per broker loses the cross-node ordering and quorum/ISR batching that a single roller instance provides across all nodes, re-creates admin clients on every call, and re-derives ordering (controllers vs brokers, unready-first) that the roller does for free. Given those losses, this proposal recommends the in-roller hook (with the strict pre-restart placement above) as the primary approach, but the per-broker-`maybeRollKafka` variant is a viable fallback if maintainers prefer not to widen the `KafkaRoller` boundary, and the choice should be settled during review.
+
+## Affected/not affected projects
+
+This proposal affects the **Strimzi Cluster Operator** only:
+
+- Phase 1: the `api` module (a `nodePortTemplate` field on the listener configuration), `ListenersValidator`, `ListenersUtils`/`ServiceUtils` rendering, plus CRD/examples/docs.
+- Phase 2: `KafkaReconciler` (reconcile ordering), `KafkaListenersReconciler` (split into shared / per-broker / bootstrap reconciliation), and `KafkaRoller` (a strictly-placed, idempotent pre-restart hook and just-in-time advertised host/port supply) — or, under the alternative, the per-broker `maybeRollKafka` driver instead of a `KafkaRoller` change.
+
+No other Strimzi projects are affected. Only KRaft-based clusters are in scope (see [KRaft assumption](#kraft-assumption)).
+
+## Compatibility
+
+- **Behaviour is unchanged for non-connectivity-affecting reconciliations**, and for connectivity changes on internal listeners (which fall back to current behaviour).
+- **Phase 1 is fully backwards compatible**: `nodePortTemplate` is optional and explicit per-broker `nodePort` still wins.
+- **Phase 2 needs no API/CRD change.**
+- **Reconciliation takes longer** for connectivity-affecting changes, because per-broker resource reconciliation (and waiting for an asynchronously-assigned address) is interleaved with the roll. This is most pronounced for `loadbalancer`, where each per-broker LB is provisioned by the cloud (often minutes) and is now serialized across the roll; for large clusters (200+ brokers) the total can be very large. Per-broker waits are bounded by `operationTimeoutMs`, but the overall reconcile may approach or exceed the reconciliation interval, so overlap/lock behaviour and progress logging must be considered. The migration is resumable (per-broker convergence guard), so an aborted reconcile continues on the next pass rather than restarting from scratch.
+- **Listener status** is fully populated only after the roll completes; intermediate reconcile passes may report a mix of old and new per-broker addresses, all valid at the time.
+
+## Rejected alternatives
+
+### Roll all `Service`s, then delete all pods at once
+
+Forcing a full, simultaneous pod restart (as was done manually to recover the incident) makes the cluster consistent quickly but causes a hard, total outage during the restart and defeats the purpose of rolling updates. Rejected.
+
+### Make clients tolerate the mismatch
+
+Relying on client-side retry/metadata-refresh tuning to ride out the window does not work when the `Service` actively fronts the *wrong* listener (auth-mechanism mismatch) or the port no longer exists for a sustained period. The operator must keep server-side `Service`s consistent with the running brokers. Rejected.
+
+### Phase 1 only (deterministic ports, keep all-`Service`s-at-once)
+
+Stable node ports eliminate the severe collision/auth-mismatch but leave the availability window where a not-yet-rolled broker's `Service` already advertises a listener it is not yet serving (e.g. on a `nodeport` ↔ `cluster-ip` type change). Acceptable as a first step and shippable on its own, but not a complete fix — hence Phase 2.
+
+### Phase 2 only (coupling, keep random ports)
+
+Coupling removes the availability window but, without stable ports, a `nodeport` type change still re-allocates random ports, so a client momentarily targeting the old port of a just-rolled broker can still transiently hit a colliding listener before refreshing metadata. Stable ports make per-broker port changes deterministic and collision-free, so Phase 1 remains worthwhile even with Phase 2. Rejected as a standalone solution.

--- a/148-safe-listener-connectivity-rollout.md
+++ b/148-safe-listener-connectivity-rollout.md
@@ -116,6 +116,19 @@ It cannot be a single cluster-global flag.
 Brokers already at the desired state are skipped, so a re-run resumes the migration instead of re-rolling the whole cluster.
 This makes the operation convergent and resumable.
 
+### Startup and recovery
+
+The coupled path is only for an in-place change to a listener that brokers are actively serving.
+Initial cluster creation and recovery are different: the per-broker resources are simply absent, not switched under a running broker, so there is no mismatch window to protect.
+In those cases the operator keeps the current up-front reconciliation and creates all listener resources before the pods start.
+
+Brokers also do not depend on the external client listener to find each other.
+Quorum and replication use the internal control-plane and replication listeners on the headless `brokers` service, which are always reconciled up front and are never part of a connectivity change (see [Precondition](#precondition-the-internal-listeners-are-never-part-of-the-change)).
+So bringing brokers up one by one during startup or recovery is unaffected by this proposal.
+
+The cost is that the detector must reliably distinguish an in-place change to a serving listener from absent resources during creation or recovery, and fall back to the up-front path for the latter.
+The combined case, where a recovery happens while a connectivity change is still pending in the custom resource, is exactly the kind of multi-state edge case that makes this harder to justify.
+
 ### Per-broker rollout loop
 
 For each broker that is not yet converged, in the order and under the safety gates the existing roll already enforces:

--- a/148-safe-listener-connectivity-rollout.md
+++ b/148-safe-listener-connectivity-rollout.md
@@ -34,23 +34,9 @@ Some listener types do not have a stable externally-visible address across a res
 
 `cluster-ip`, `route`, and `ingress` addresses are derived deterministically from resource names, so they suffer Failure mode A but not B.
 
-### Incident this addresses
-
-A large `nodeport`-based cluster (a few hundred nodes) exposed two SASL listeners (SCRAM and Kerberos) as per-broker `NodePort` services.
-A deployment switched the listeners to `cluster-ip` and was then rolled back to `nodeport`.
-The rollback re-allocated random node ports — some SCRAM ports landed on Kerberos and vice versa — and, because all `Service`s were switched at once while brokers restarted one by one, brokers that had not yet restarted had `Service`s that no longer matched their running listeners.
-Clients holding cached metadata kept hitting the wrong port/mechanism and produced errors such as:
-
-```
-Client SASL mechanism 'SCRAM-SHA-512' not enabled in the server, enabled mechanisms are [GSSAPI]
-Client SASL mechanism 'GSSAPI' not enabled in the server, enabled mechanisms are [SCRAM-SHA-512]
-```
-
-Reads and writes failed cluster-wide for ~3 hours and only recovered after every broker pod was deleted to force a full, consistent reconcile.
-
 ## Motivation
 
-The root cause is an **atomicity mismatch**: listener resources are switched atomically for the whole cluster, but the brokers that back those resources converge gradually as they restart one by one. During that window every not-yet-rolled broker advertises a listener it is not yet serving, so clients fail to connect; and because most of the cluster is unreachable, clients cannot refresh their metadata to recover. On `nodeport`/`loadbalancer` the same window is what makes a port/address reshuffle dangerous (Failure mode B): without a reachable cluster to refresh from, cached clients keep hitting stale — and possibly cross-wired — endpoints.
+The root cause is an **atomicity mismatch**: listener resources are switched atomically for the whole cluster, but the brokers that back those resources converge gradually as they restart one by one. During that window every not-yet-rolled broker advertises a listener it is not yet serving, so clients fail to connect; and because most of the cluster is unreachable, clients cannot refresh their metadata to recover. On `nodeport`/`loadbalancer` the same window is what makes a port/address reshuffle dangerous (Failure mode B): without a reachable cluster to refresh from, cached clients keep hitting stale — and possibly cross-wired — endpoints (for example a SASL client reaching a port now serving a different mechanism), which on a real cluster has produced cluster-wide produce/consume failures for the entire duration of a listener type change and rollback.
 
 Reconciling each broker's listener resources in lockstep with that broker's own restart removes the window: at every instant each broker is internally consistent (its resources match the listener it is running), so the change rolls through the cluster the same safe way a normal restart does, and clients can always refresh metadata against the parts of the cluster that are still up.
 

--- a/148-safe-listener-connectivity-rollout.md
+++ b/148-safe-listener-connectivity-rollout.md
@@ -1,10 +1,18 @@
 # Safe rollout of listener connectivity changes
 
-Make connectivity-affecting listener changes (listener type changes, port changes, adding/removing a listener) safe to roll out and roll back, for **all listener types that provision per-broker Kubernetes resources** — `nodeport`, `loadbalancer`, `cluster-ip`, `route`, and `ingress`.
+Make connectivity-affecting listener changes safe to roll out and roll back.
+These changes are listener type changes, port changes, and adding or removing a listener.
+This covers all listener types that provision per-broker Kubernetes resources: `nodeport`, `loadbalancer`, `cluster-ip`, `route`, and `ingress`.
 
-The proposal reconciles each broker's listener resources (its `Service`, and `Route`/`Ingress` where applicable) **in lockstep with that broker's own restart**, instead of replacing all per-broker resources for the whole cluster up front while the brokers restart one by one. This removes the availability window — present for every per-broker listener type — where a not-yet-rolled broker's resources already point at a listener the broker is not yet serving.
+The proposal reconciles each broker's listener resources in lockstep with that broker's own restart.
+Those resources are the broker's `Service`, plus its `Route` or `Ingress` where applicable.
+Today the operator replaces every per-broker resource for the whole cluster up front and then restarts the brokers one by one.
+Reconciling per broker removes the availability window where a not-yet-rolled broker's resources already point at a listener the broker is not yet serving.
+That window exists for every per-broker listener type.
 
-> **Scope: KRaft only.** This proposal assumes KRaft-based Kafka clusters and does not consider ZooKeeper-based clusters (ZooKeeper support has been removed from current Strimzi). The partial-roll correctness argument relies on KRaft broker-registration semantics (see [KRaft assumption](#kraft-assumption)).
+> **Scope: KRaft only.**
+> This proposal assumes KRaft-based Kafka clusters and does not cover ZooKeeper-based clusters, which have already been removed from current Strimzi.
+> The partial-roll correctness argument relies on KRaft broker-registration semantics (see [KRaft assumption](#kraft-assumption)).
 
 ## Current situation
 
@@ -20,41 +28,62 @@ The Kafka reconciliation pipeline reconciles listeners and rolls the pods in two
 .compose(podSetDiffs -> rollingUpdate(podSetDiffs)) // (3) restart pods ONE BY ONE
 ```
 
-In phase (1), `listeners()` reconciles the shared bootstrap resources and **every** per-broker listener resource at once. Each external listener provisions per-broker Kubernetes objects — a `Service` for `nodeport`/`loadbalancer`/`cluster-ip`, plus a `Route` (`route`) or `Ingress` (`ingress`) — and they are all reconciled cluster-wide before any pod rolls.
+In phase (1), `listeners()` reconciles the shared bootstrap resources and every per-broker listener resource at once.
+Each external listener provisions per-broker Kubernetes objects: a `Service` for `nodeport`, `loadbalancer`, and `cluster-ip`, plus a `Route` for `route` or an `Ingress` for `ingress`.
+All of these are reconciled cluster-wide before any pod rolls.
 
-The brokers, however, only pick up the new listener configuration when they restart, which happens **one pod at a time** in phase (3). This gap produces two failure modes.
+The brokers only pick up the new listener configuration when they restart, and that happens one pod at a time in phase (3).
+This gap produces two failure modes.
 
 #### Failure mode A — resource/broker mismatch window (all per-broker listener types)
 
-When the listener **type** changes (for example `nodeport` → `cluster-ip` or a rollback back to `nodeport`), a `port` changes, or a listener is added/removed, all per-broker resources are switched/replaced immediately, but each broker only starts serving the new listener when it restarts. Brokers that have **not yet** restarted still serve the **old** listener, but their resources have **already** been switched. Clients connecting to those brokers fail (connection refused / unreachable / wrong endpoint) for the whole duration of the roll, not just briefly during a restart. This applies to **every** per-broker listener type, regardless of how addresses are assigned.
+This covers a listener `type` change (for example `nodeport` to `cluster-ip`, or a rollback to `nodeport`), a `port` change, or adding or removing a listener.
+All per-broker resources are switched immediately, but each broker only starts serving the new listener when it restarts.
+Brokers that have not yet restarted still serve the old listener while their resources already point at the new one.
+Clients connecting to those brokers fail for the whole duration of the roll, not just briefly during a restart.
+The failures look like connection refused, unreachable, or wrong endpoint.
+This applies to every per-broker listener type, regardless of how addresses are assigned.
 
 #### Failure mode B — address churn on resource recreate (`nodeport` and `loadbalancer`)
 
-Some listener types do not have a stable externally-visible address across a resource recreate: a `nodeport` `Service`'s node port is preserved only when the old and new `Service` are both already `NodePort`, so across a **type change** Kubernetes allocates fresh random ports on the way back to `NodePort`; a `loadbalancer` `Service` may get a new external IP/hostname on recreate. Combined with Failure mode A, the consequence can be severe: a port that previously fronted one listener may be reallocated to a *different* listener, so a client with cached metadata that cannot refresh (because the rest of the cluster is unreachable mid-roll) sends, for example, a SCRAM handshake to a port now serving the Kerberos listener — an authentication-protocol mismatch.
+Some listener types do not keep a stable externally-visible address across a resource recreate.
+A `nodeport` `Service` keeps its node port only when the old and new `Service` are both already `NodePort`, so a type change makes Kubernetes allocate fresh random ports on the way back to `NodePort`.
+A `loadbalancer` `Service` may get a new external IP or hostname on recreate.
+Combined with Failure mode A, this can be severe: a port that previously fronted one listener can be reallocated to a different listener.
+A client with cached metadata that cannot refresh, because the rest of the cluster is unreachable mid-roll, then sends (for example) a SCRAM handshake to a port now serving the Kerberos listener, which is an authentication-protocol mismatch.
 
-`cluster-ip`, `route`, and `ingress` addresses are derived deterministically from resource names, so they suffer Failure mode A but not B.
+`cluster-ip`, `route`, and `ingress` addresses are derived deterministically from resource names, so they hit Failure mode A but not B.
 
 ## Motivation
 
-The root cause is an **atomicity mismatch**: listener resources are switched atomically for the whole cluster, but the brokers that back those resources converge gradually as they restart one by one. During that window every not-yet-rolled broker advertises a listener it is not yet serving, so clients fail to connect; and because most of the cluster is unreachable, clients cannot refresh their metadata to recover. On `nodeport`/`loadbalancer` the same window is what makes a port/address reshuffle dangerous (Failure mode B): without a reachable cluster to refresh from, cached clients keep hitting stale — and possibly cross-wired — endpoints (for example a SASL client reaching a port now serving a different mechanism), which on a real cluster has produced cluster-wide produce/consume failures for the entire duration of a listener type change and rollback.
+The root cause is an atomicity mismatch.
+Listener resources are switched atomically for the whole cluster, but the brokers behind them converge gradually as they restart one by one.
+During that window every not-yet-rolled broker advertises a listener it is not yet serving, so clients fail to connect.
+Because most of the cluster is unreachable, clients cannot refresh their metadata to recover.
+On `nodeport` and `loadbalancer` the same window is what makes a port or address reshuffle dangerous (Failure mode B): with no reachable cluster to refresh from, cached clients keep hitting stale, and possibly cross-wired, endpoints (for example a SASL client reaching a port now serving a different mechanism).
+On a real cluster this has caused cluster-wide produce and consume failures for the entire duration of a listener type change and rollback.
 
-Reconciling each broker's listener resources in lockstep with that broker's own restart removes the window: at every instant each broker is internally consistent (its resources match the listener it is running), so the change rolls through the cluster the same safe way a normal restart does, and clients can always refresh metadata against the parts of the cluster that are still up.
+Reconciling each broker's listener resources in lockstep with that broker's own restart removes the window.
+At every instant each broker is internally consistent, because its resources match the listener it is running.
+The change then rolls through the cluster the same safe way a normal restart does, and clients can always refresh metadata against the parts of the cluster that are still up.
 
 ## Proposal
 
-When a reconciliation includes a **connectivity-affecting listener change**, reconcile the per-broker listener resources (the broker's `Service`, and its `Route`/`Ingress` where applicable) as part of the rolling update, broker by broker, instead of all at once before the roll.
+When a reconciliation includes a connectivity-affecting listener change, reconcile the per-broker listener resources as part of the rolling update, broker by broker, instead of all at once before the roll.
+The per-broker resources are the broker's `Service`, plus its `Route` or `Ingress` where applicable.
 
-A change is "connectivity-affecting" when it changes what a client must connect to:
+A change is connectivity-affecting when it changes what a client must connect to:
 
 - a listener's `type` changes;
 - a listener's `port` changes;
 - a listener is added or removed.
 
-All other reconciliations (config-only changes, certificate rotations, image upgrades, scaling, etc.) keep the current behaviour unchanged.
+All other reconciliations keep the current behaviour unchanged: config-only changes, certificate rotations, image upgrades, scaling, and so on.
 
 ### Precondition: the internal listeners are never part of the change
 
-The rolling update's safety checks (quorum / in-sync-replica `canRoll`) depend on the operator's admin client, which connects over the **internal** replication and control-plane listeners (the headless `brokers` service on `REPLICATION_PORT` / `CONTROLPLANE_PORT`), not the external listener being changed:
+The rolling update's safety checks (the quorum and in-sync-replica `canRoll` checks) depend on the operator's admin client.
+That client connects over the internal replication and control-plane listeners (the headless `brokers` service on `REPLICATION_PORT` and `CONTROLPLANE_PORT`), not the external listener being changed:
 
 ```java
 // KafkaRoller.adminClient(...)
@@ -63,30 +92,40 @@ bootstrapHostnames = nodes.stream().filter(NodeRef::broker)
     .collect(Collectors.joining(","));
 ```
 
-This is exactly what makes the approach safe: the external listener can be in flux while the operator still reaches the cluster for availability checks. The coupled path is therefore valid **only for external/client listeners**; a change to the internal replication/control listener cannot use this mechanism and must fall back to the current behaviour (or be disallowed). The detector must guard for this.
+This is what makes the approach safe: the external listener can be in flux while the operator still reaches the cluster for availability checks.
+The coupled path is therefore valid only for external client listeners.
+A change to the internal replication or control listener cannot use this mechanism and must fall back to the current behaviour, or be disallowed.
+The detector must guard for this.
 
 ### Per-broker convergence guard (idempotency)
 
-Reconciliations can be interrupted and re-run, leaving the cluster half-migrated (some brokers new, some old). The "connectivity change" decision must therefore be evaluated **per broker** — "do this broker's observed listener resources already match the desired listener config?" — not as a single cluster-global flag. Brokers already at the desired state are skipped, so a re-run resumes the migration instead of re-rolling the whole cluster. This makes the operation convergent and resumable.
+Reconciliations can be interrupted and re-run, which can leave the cluster half-migrated with some brokers new and some old.
+The connectivity-change decision must therefore be evaluated per broker, by asking whether this broker's observed listener resources already match the desired listener config.
+It cannot be a single cluster-global flag.
+Brokers already at the desired state are skipped, so a re-run resumes the migration instead of re-rolling the whole cluster.
+This makes the operation convergent and resumable.
 
 ### Per-broker rollout loop
 
 For each broker that is not yet converged, in the order and under the safety gates the existing roll already enforces:
 
-1. Reconcile **that broker's** listener resource(s) — `Service`, and `Route`/`Ingress` where applicable — to the desired state (create/update/delete). For types whose externally-visible address is assigned asynchronously, wait until it is available for that broker: the assigned `nodePort` (`nodeport`), the load-balancer ingress IP/hostname (`loadbalancer`), or the admitted host (`route`). `cluster-ip`/`ingress` addresses are deterministic and need no wait.
-2. Render **that broker's** configuration with the resulting `advertised.listeners` and apply its `ConfigMap`.
+1. Reconcile that broker's listener resources (`Service`, plus `Route`/`Ingress` where applicable) to the desired state, creating, updating, or deleting as needed.
+   For types whose externally-visible address is assigned asynchronously, wait until it is available for that broker: the assigned `nodePort` for `nodeport`, the load-balancer ingress IP or hostname for `loadbalancer`, or the admitted host for `route`.
+   `cluster-ip` and `ingress` addresses are deterministic and need no wait.
+2. Render that broker's configuration with the resulting `advertised.listeners` and apply its `ConfigMap`.
 3. Restart the broker so it starts serving the new listener and re-registers its advertised endpoint.
 4. Wait until the broker is ready before moving to the next broker.
 
 ### Bootstrap resource
 
-The bootstrap resource is shared (one `Service`/`Route`/`Ingress` for the whole listener) and is reconciled **last**, after all brokers have rolled.
-This avoids switching the shared entry point until the per-broker endpoints behind it are all consistent, and makes the bootstrap change a single, fast operation at the end.
-Note this does **not** guarantee a *reachable* bootstrap throughout the roll: if the bootstrap's current state is itself part of the change (e.g. mid-rollback it is still the wrong type), clients doing a cold start or metadata refresh *through the bootstrap* recover only once it flips at the end. Clients holding cached per-broker metadata are unaffected (see below).
+The bootstrap resource is shared, one `Service`, `Route`, or `Ingress` for the whole listener, and is reconciled last, after all brokers have rolled.
+This avoids switching the shared entry point until the per-broker endpoints behind it are all consistent, and it makes the bootstrap change a single fast operation at the end.
+This does not guarantee a reachable bootstrap throughout the roll: if the bootstrap's current state is itself part of the change (for example, mid-rollback it is still the wrong type), clients doing a cold start or metadata refresh through the bootstrap recover only once it flips at the end.
+Clients holding cached per-broker metadata are unaffected (see below).
 
 ### Availability during a partial roll
 
-A half-rolled cluster does **not** cause widespread failure for clients with cached metadata; it degrades to an ordinary rolling restart.
+A half-rolled cluster does not cause widespread failure for clients with cached metadata; it degrades to an ordinary rolling restart.
 
 For any partition, such a client connects to the leader's currently-advertised address:
 
@@ -94,61 +133,80 @@ For any partition, such a client connects to the leader's currently-advertised a
 - leader on a not-yet-rolled broker → metadata gives the old address, the old resource still exists → works;
 - leader on the broker currently restarting → brief unavailability while leadership fails over to an in-sync replica, covered by normal client retries (RF ≥ 2).
 
-This also bounds the impact of address churn (Failure mode B). Because each broker's resource is switched in lockstep with its restart and the rest of the cluster stays reachable, a client targeting a stale `nodeport`/`loadbalancer` address simply refreshes its metadata and connects to that broker's current address. A reshuffled or cross-wired port affects at most one broker momentarily and is self-healed by a metadata refresh — instead of the sustained, cluster-wide outage that occurs today when the whole cluster is switched at once and clients cannot refresh.
+This also bounds the impact of address churn (Failure mode B).
+Because each broker's resource is switched in lockstep with its restart and the rest of the cluster stays reachable, a client targeting a stale `nodeport` or `loadbalancer` address simply refreshes its metadata and connects to that broker's current address.
+A reshuffled or cross-wired port affects at most one broker for a moment and is self-healed by a metadata refresh, rather than the sustained cluster-wide outage that occurs today when the whole cluster is switched at once and clients cannot refresh.
 
 Remaining failure modes are the ordinary ones, not new to this change:
 
-- **RF = 1 topics**: partitions led by the broker currently restarting are unavailable until it returns (true for any restart).
-- **Cold-start / bootstrap-dependent clients**: see the bootstrap note above — they recover when the bootstrap flips at the end.
-- **Momentary stale metadata**: a client that cached a broker's address immediately before that broker rolls gets a single failed connection and recovers on the next metadata refresh.
+- **RF = 1 topics:** partitions led by the broker currently restarting are unavailable until it returns, which is true for any restart.
+- **Cold-start or bootstrap-dependent clients:** see the bootstrap note above; they recover when the bootstrap flips at the end.
+- **Momentary stale metadata:** a client that cached a broker's address immediately before that broker rolls gets a single failed connection and recovers on the next metadata refresh.
 
-This is fundamentally different from the current behaviour, where a not-yet-rolled broker's mismatched resources fail *all* connections to it for the *entire* roll.
+This is different from the current behaviour, where a not-yet-rolled broker's mismatched resources fail all connections to it for the entire roll.
 
 ### KRaft assumption
 
-The partial-roll correctness argument depends on KRaft semantics and applies to **KRaft-based clusters only**:
+The partial-roll correctness argument depends on KRaft semantics and applies to KRaft-based clusters only:
 
-- Each broker registers its **own** `advertised.listeners` with the KRaft controller on start-up, and the controller propagates the full set of broker endpoints to all brokers. A broker re-registering a new endpoint when it rolls is therefore enough for the rest of the cluster (and client metadata) to see the change — Strimzi does **not** need to rewrite every broker's configuration up front for the new addresses to become visible. This is what makes incremental per-broker convergence safe.
-- Each broker's advertised address depends only on **that broker's own** resources, so its config can be rendered from its own resources alone, with no cross-broker dependency: for `nodeport` the advertised host is resolved by the pod from its scheduled node (via an env var) and only the port comes from the broker's `Service`; for `loadbalancer` the address comes from that broker's LB `Service` ingress; for `cluster-ip` from its per-broker DNS name; for `route`/`ingress` from that broker's `Route`/`Ingress` host.
-- Controller-only KRaft nodes have no client listeners and are skipped by the per-broker resource/config steps.
+- Each broker registers its own `advertised.listeners` with the KRaft controller on start-up, and the controller propagates the full set of broker endpoints to all brokers.
+  A broker re-registering a new endpoint when it rolls is therefore enough for the rest of the cluster, and for client metadata, to see the change.
+  Strimzi does not need to rewrite every broker's configuration up front for the new addresses to become visible, which is what makes incremental per-broker convergence safe.
+- Each broker's advertised address depends only on that broker's own resources, so its config can be rendered from its own resources alone, with no cross-broker dependency.
+  For `nodeport` the advertised host is resolved by the pod from its scheduled node (via an env var) and only the port comes from the broker's `Service`; for `loadbalancer` the address comes from that broker's LB `Service` ingress; for `cluster-ip` from its per-broker DNS name; for `route` and `ingress` from that broker's `Route` or `Ingress` host.
+- Controller-only KRaft nodes have no client listeners and are skipped by the per-broker resource and config steps.
 
 ZooKeeper-based clusters are explicitly out of scope.
 
 ### Implementation sketch
 
-The change is an ordering/wiring change in the Cluster Operator; the building blocks already exist.
+This is an ordering and wiring change in the Cluster Operator, and the building blocks already exist.
 
 **1. Detect connectivity change, per broker.**
-Before the roll, for each broker compare the desired listener config against the observed per-broker resources to compute whether that broker needs a coupled reconcile. If no broker needs one, the reconciliation keeps the **current** behaviour exactly (`listeners()` → `perBrokerKafkaConfiguration()` → `podSet()` → `rollingUpdate()`). The new path is taken only for connectivity changes on external listeners (per the precondition above).
+Before the roll, for each broker, compare the desired listener config against the observed per-broker resources to decide whether that broker needs a coupled reconcile.
+If no broker needs one, the reconciliation keeps the current behaviour exactly (`listeners()` → `perBrokerKafkaConfiguration()` → `podSet()` → `rollingUpdate()`).
+The new path is taken only for connectivity changes on external listeners (per the precondition above).
 
 **2. Split `KafkaListenersReconciler.reconcile()` into reusable pieces.**
-Today it reconciles bootstrap + all per-broker resources and returns one `ReconciliationResult` (with `advertisedHostnames` / `advertisedPorts`, both `Map<Integer, Map<String, String>>`). Factor out:
+Today it reconciles the bootstrap plus all per-broker resources and returns one `ReconciliationResult` (with `advertisedHostnames` and `advertisedPorts`, both `Map<Integer, Map<String, String>>`).
+Factor out:
 
-- `reconcileSharedPrerequisites()` — listener `Secret`s/certificates and other non-connectivity, non-bootstrap resources.
-- `reconcileBrokerListener(NodeRef)` — reconcile **one** broker's per-broker resources (`Service`, and `Route`/`Ingress` where applicable), wait for that broker's asynchronously-assigned address where relevant (`nodePort` / LB ingress / route host), and return that broker's `advertisedHostnames` / `advertisedPorts` entries. This generalizes the existing per-listener-type readiness steps (`nodePortServicesReady`, `loadBalancerServicesReady`, `routesReady`, …) to operate on a single broker.
-- `reconcileBootstrap()` — the shared bootstrap resource (`Service`/`Route`/`Ingress`) and final listener status.
+- `reconcileSharedPrerequisites()` — listener `Secret`s and certificates, and other non-connectivity, non-bootstrap resources.
+- `reconcileBrokerListener(NodeRef)` — reconcile one broker's per-broker resources (`Service`, plus `Route`/`Ingress` where applicable), wait for that broker's asynchronously-assigned address where relevant (`nodePort`, LB ingress, or route host), and return that broker's `advertisedHostnames` and `advertisedPorts` entries.
+  This generalizes the existing per-listener-type readiness steps (`nodePortServicesReady`, `loadBalancerServicesReady`, `routesReady`, and so on) to operate on a single broker.
+- `reconcileBootstrap()` — the shared bootstrap resource (`Service`/`Route`/`Ingress`) and the final listener status.
 
 **3. Drive the per-broker resource reconcile from the exact pre-restart moment.**
-The roll iterates node by node on a single-threaded executor via `maybeRollKafka(...)` → `KafkaRoller`. A node can be *considered* many times and deferred (`UnforceableProblem` + backoff) when `canRoll` fails, so the only correct place to switch a broker's resources is **immediately before the pod is actually deleted** — i.e. right before each `restartAndAwaitReadiness(...)` call, *after* the availability gate has passed. There are three such call sites in `restartIfNecessary(...)`:
+The roll iterates node by node on a single-threaded executor via `maybeRollKafka(...)` → `KafkaRoller`.
+A node can be considered many times and deferred (`UnforceableProblem` plus backoff) when `canRoll` fails, so the only correct place to switch a broker's resources is immediately before the pod is actually deleted, right before each `restartAndAwaitReadiness(...)` call, after the availability gate has passed.
+There are three such call sites in `restartIfNecessary(...)`:
 
-- the `forceRestart` branch (used for stuck/unresponsive/old-revision pods — *not* the connectivity-change path, which is `needsRestart`);
+- the `forceRestart` branch, used for stuck, unresponsive, or old-revision pods, which is not the connectivity-change path (that path is `needsRestart`);
 - the normal `needsRestart`/`needsReconfig` branch, reached only after `canRoll(...)` returns true;
 - the force-roll-on-error fallback, reached only after `canRoll(..., true, ...)` returns true.
 
-The hook (`reconcileBrokerListener(node)` + that broker's `ConfigMap` update) must:
+The hook (`reconcileBrokerListener(node)` plus that broker's `ConfigMap` update) must:
 
-- fire only at those points, never when a node is merely "considered" (otherwise the broker's resources are switched while the still-running broker serves the old listener — the exact bug, localized to one broker for the duration of a deferral);
-- be **idempotent**, because a node may pass `canRoll` and still be retried;
-- run before **every** restart of a not-yet-converged broker, including the `forceRestart` and force-roll-on-error branches (see below).
+- fire only at those points, never when a node is merely considered, otherwise the broker's resources are switched while the still-running broker serves the old listener, which is the exact bug localized to one broker for the duration of a deferral;
+- be idempotent, because a node may pass `canRoll` and still be retried;
+- run before every restart of a not-yet-converged broker, including the `forceRestart` and force-roll-on-error branches (see below).
 
-A connectivity change is signalled by `podNeedsRestart` returning a new reason (e.g. `LISTENER_CONFIGURATION_CHANGE`) for brokers that are not yet converged. This yields `needsRestart = true` (so it is gated by `canRoll`) and short-circuits the dynamic-reconfiguration path (`advertised.listeners` is not dynamically updatable anyway).
+A connectivity change is signalled by `podNeedsRestart` returning a new reason (for example `LISTENER_CONFIGURATION_CHANGE`) for brokers that are not yet converged.
+This yields `needsRestart = true`, so it is gated by `canRoll`, and it short-circuits the dynamic-reconfiguration path (`advertised.listeners` is not dynamically updatable anyway).
 
-**Handling the `forceRestart` branch.** Although a connectivity change itself maps to `needsRestart` (not `forceRestart`), a not-yet-converged broker can still hit the `forceRestart`/force-roll-on-error path for an *unrelated* reason — e.g. the pod is stuck, unresponsive, or on an old revision — during the migration. If the listener hook only ran on the `needsRestart` branch, such a broker would be restarted with its resources/`ConfigMap` still on the old listener and would come back mismatched, converging only on a later reconcile. The hook must therefore key off "is this broker not yet converged?" and run before the restart on **all** branches. Because the hook is idempotent and only reconciles that broker's own resources, doing so on the force paths is safe.
+**Handling the `forceRestart` branch.**
+Although a connectivity change itself maps to `needsRestart` rather than `forceRestart`, a not-yet-converged broker can still hit the `forceRestart` or force-roll-on-error path for an unrelated reason during the migration, for example a stuck, unresponsive, or old-revision pod.
+If the listener hook only ran on the `needsRestart` branch, such a broker would be restarted with its resources and `ConfigMap` still on the old listener and would come back mismatched, converging only on a later reconcile.
+The hook must therefore key off whether the broker is not yet converged and run before the restart on all branches.
+Because the hook is idempotent and only reconciles that broker's own resources, doing this on the force paths is safe.
 
 **4. Avoid the PodSet "double-roll".**
-The advertised host/port hash is folded into the broker config hash and surfaced as a **pod annotation** (`perBrokerKafkaConfiguration()` → `podSetPodAnnotations()`), and `podSet()` runs *before* the roll and can itself restart pods when annotations change. If the new advertised config were applied up front, `podSet()` would roll pods prematurely — with the new annotation but before the per-broker resource hook runs. The implementation must therefore keep the up-front `podSet()` carrying the **old** advertised hash and apply each broker's new config/annotation during the roll (step 3), so a broker is rolled exactly once, by `KafkaRoller`, with its resources already switched. This is the most delicate part of the implementation and must be covered by tests.
+The advertised host and port hash is folded into the broker config hash and surfaced as a pod annotation (`perBrokerKafkaConfiguration()` → `podSetPodAnnotations()`), and `podSet()` runs before the roll and can itself restart pods when annotations change.
+If the new advertised config were applied up front, `podSet()` would roll pods prematurely, with the new annotation but before the per-broker resource hook runs.
+The implementation must therefore keep the up-front `podSet()` carrying the old advertised hash and apply each broker's new config and annotation during the roll (step 3), so a broker is rolled exactly once, by `KafkaRoller`, with its resources already switched.
+This is the most delicate part of the implementation and must be covered by tests.
 
-**5. Reconcile the bootstrap last**, then populate listener status.
+**5. Reconcile the bootstrap last**, then populate the listener status.
 
 Resulting high-level flow in `KafkaReconciler.reconcile()` for a connectivity-affecting change:
 
@@ -168,58 +226,76 @@ reconcileSharedPrerequisites()        // certs/secrets, no connectivity change
 **Edge cases / notes.**
 
 - If a broker fails to roll, the bootstrap is never switched; the cluster is left in a still-functional mixed state (each broker self-consistent) and the next reconcile resumes via the per-broker convergence guard.
-- `KafkaRoller`'s existing controller/quorum and in-sync-replica safety checks are unchanged and continue to gate each broker's restart.
+- `KafkaRoller`'s existing controller, quorum, and in-sync-replica safety checks are unchanged and continue to gate each broker's restart.
 
 ### Decision: in-roller hook (and the rejected alternative)
 
-**This proposal recommends the in-roller hook** described above: a single `KafkaRoller` instance for the whole roll, with the strictly-placed, idempotent pre-restart hook reconciling each broker's resources.
+This proposal recommends the in-roller hook described above: a single `KafkaRoller` instance for the whole roll, with a strictly-placed, idempotent pre-restart hook that reconciles each broker's resources.
 
-The decision is driven by **safety over boundary-cleanliness**. A single `KafkaRoller` instance holds the cluster-wide view needed to roll safely — controller-first ordering, unready-first ordering, and quorum/ISR `canRoll` checks evaluated across all nodes. Preserving that global view is the property that actually protects availability during the roll, and it is the harder thing to get right.
+The decision favours safety over a clean boundary.
+A single `KafkaRoller` instance holds the cluster-wide view needed to roll safely: controller-first ordering, unready-first ordering, and quorum/ISR `canRoll` checks evaluated across all nodes.
+Preserving that global view is what protects availability during the roll, and it is the harder thing to get right.
 
-The rejected alternative is to drive the roll from the listener reconciler by calling `maybeRollKafka(...)` with a **single-node set per broker**, reconciling that broker's resources between calls. This keeps resource/`ConfigMap` I/O out of `KafkaRoller` and preserves its clean "pods + admin client only" boundary — attractive, but it spins up a fresh roller per broker, which loses the cross-node ordering and quorum/ISR batching, re-creates admin clients on every call, and re-derives ordering the roller otherwise does for free. Trading away the roller's global safety reasoning to keep a code boundary tidy is the wrong trade for the operator's most safety-critical path, so this variant is rejected. The cost of the chosen approach — widening `KafkaRoller`'s responsibility — is contained by the strict hook placement and idempotency requirements above and must be covered by tests.
+The rejected alternative is to drive the roll from the listener reconciler by calling `maybeRollKafka(...)` with a single-node set per broker, reconciling that broker's resources between calls.
+This keeps resource and `ConfigMap` I/O out of `KafkaRoller` and preserves its clean "pods plus admin client only" boundary.
+The downside is that it spins up a fresh roller per broker, which loses the cross-node ordering and quorum/ISR batching, re-creates admin clients on every call, and re-derives ordering the roller otherwise does for free.
+Giving up the roller's global safety reasoning to keep a code boundary tidy is the wrong trade for the operator's most safety-critical path, so this variant is rejected.
+The cost of the chosen approach, widening `KafkaRoller`'s responsibility, is contained by the strict hook placement and idempotency requirements above and must be covered by tests.
 
 ### Feature gate and rollout
 
-Because this changes the behaviour of the reconcile/roll path — the operator's most safety-critical area — it is introduced behind a **feature gate** (e.g. `CoupledListenerRollout`), following Strimzi's usual gate lifecycle:
+Because this changes the reconcile and roll path, the operator's most safety-critical area, it is introduced behind a feature gate (for example `CoupledListenerRollout`), following Strimzi's usual gate lifecycle:
 
 - **Alpha (disabled by default):** opt-in for early adopters and CI; the current all-at-once behaviour remains the default.
-- **Beta (enabled by default):** after the test matrix below is green across supported listener types, with the gate still available to disable.
+- **Beta (enabled by default):** after the test matrix below is green across the supported listener types, with the gate still available to disable.
 - **GA / gate removal:** once proven in the field.
 
-When the gate is disabled, the code path is exactly today's behaviour, so the change is risk-free to ship dark.
+When the gate is disabled, the code path is exactly today's behaviour, so the change is safe to ship dark.
 
 ### Testing
 
 The proposal is only credible with explicit coverage of the partial-roll states it claims to make safe:
 
-- **Unit tests** for the per-broker convergence detector (mixed/half-migrated state, internal-listener guard) and for the `KafkaRoller` hook placement (fires only pre-restart after `canRoll`, fires on the `forceRestart`/error branches for not-yet-converged brokers, is idempotent under retries, does not fire for "considered-but-deferred" nodes).
-- **Integration tests** asserting no PodSet "double-roll" occurs (each broker rolls exactly once for a connectivity change).
-- **System tests** that perform a listener `type` change and a rollback for each per-broker listener type (`nodeport`, `loadbalancer`, `cluster-ip`, `route`, `ingress`) on a multi-broker cluster, asserting clients with cached metadata keep producing/consuming throughout the roll, and that an interrupted reconcile resumes rather than re-rolling.
+- **Unit tests** for the per-broker convergence detector (mixed or half-migrated state, internal-listener guard) and for the `KafkaRoller` hook placement (fires only pre-restart after `canRoll`, fires on the `forceRestart` and error branches for not-yet-converged brokers, is idempotent under retries, and does not fire for considered-but-deferred nodes).
+- **Integration tests** asserting that no PodSet double-roll occurs, so each broker rolls exactly once for a connectivity change.
+- **System tests** that perform a listener `type` change and a rollback for each per-broker listener type (`nodeport`, `loadbalancer`, `cluster-ip`, `route`, `ingress`) on a multi-broker cluster, asserting that clients with cached metadata keep producing and consuming throughout the roll, and that an interrupted reconcile resumes rather than re-rolling.
 
 ## Affected/not affected projects
 
-This proposal affects the **Strimzi Cluster Operator** only: `KafkaReconciler` (reconcile ordering), `KafkaListenersReconciler` (split into shared / per-broker / bootstrap reconciliation), and `KafkaRoller` (a strictly-placed, idempotent pre-restart hook and just-in-time advertised host/port supply).
+This proposal affects the Strimzi Cluster Operator only: `KafkaReconciler` (reconcile ordering), `KafkaListenersReconciler` (split into shared, per-broker, and bootstrap reconciliation), and `KafkaRoller` (a strictly-placed, idempotent pre-restart hook and just-in-time advertised host and port supply).
 
-No CRD/API changes are required. No other Strimzi projects are affected. Only KRaft-based clusters are in scope (see [KRaft assumption](#kraft-assumption)).
+No CRD or API changes are required.
+No other Strimzi projects are affected.
+Only KRaft-based clusters are in scope (see [KRaft assumption](#kraft-assumption)).
 
 ## Compatibility
 
 - **Gated** behind a feature gate that is disabled by default initially (see [Feature gate and rollout](#feature-gate-and-rollout)), so it ships with zero behaviour change until explicitly enabled.
-- **Behaviour is unchanged for non-connectivity-affecting reconciliations**, and for connectivity changes on internal listeners (which fall back to current behaviour).
-- **No API/CRD change.**
-- **Reconciliation takes longer** for connectivity-affecting changes, because per-broker resource reconciliation (and waiting for an asynchronously-assigned address) is interleaved with the roll. This is most pronounced for `loadbalancer`, where each per-broker LB is provisioned by the cloud (often minutes) and is now serialized across the roll; for large clusters (200+ brokers) the total can be very large. Per-broker waits are bounded by `operationTimeoutMs`, but the overall reconcile may approach or exceed the reconciliation interval, so overlap/lock behaviour and progress logging must be considered. The migration is resumable (per-broker convergence guard), so an aborted reconcile continues on the next pass rather than restarting from scratch.
+- **Behaviour is unchanged** for non-connectivity-affecting reconciliations, and for connectivity changes on internal listeners, which fall back to the current behaviour.
+- **No API or CRD change.**
+- **Reconciliation takes longer** for connectivity-affecting changes, because per-broker resource reconciliation (and waiting for an asynchronously-assigned address) is interleaved with the roll.
+  This is most pronounced for `loadbalancer`, where each per-broker LB is provisioned by the cloud (often minutes) and is now serialized across the roll; for large clusters (200+ brokers) the total can be very large.
+  Per-broker waits are bounded by `operationTimeoutMs`, but the overall reconcile may approach or exceed the reconciliation interval, so overlap and lock behaviour and progress logging must be considered.
+  The migration is resumable (per-broker convergence guard), so an aborted reconcile continues on the next pass rather than restarting from scratch.
 - **Listener status** is fully populated only after the roll completes; intermediate reconcile passes may report a mix of old and new per-broker addresses, all valid at the time.
 
 ## Rejected alternatives
 
 ### Roll all resources, then delete all pods at once
 
-Forcing a full, simultaneous pod restart (as was done manually to recover the incident) makes the cluster consistent quickly but causes a hard, total outage during the restart and defeats the purpose of rolling updates. Rejected.
+Forcing a full simultaneous pod restart (as was done manually to recover the incident) makes the cluster consistent quickly, but it causes a hard total outage during the restart and defeats the purpose of rolling updates.
+Rejected.
 
 ### Make clients tolerate the mismatch
 
-Relying on client-side retry/metadata-refresh tuning to ride out the window does not work when the resource actively fronts the *wrong* listener (auth-mechanism mismatch) or the address no longer exists for a sustained period. The operator must keep server-side resources consistent with the running brokers. Rejected.
+Relying on client-side retry and metadata-refresh tuning to ride out the window does not work when the resource actively fronts the wrong listener (auth-mechanism mismatch) or the address no longer exists for a sustained period.
+The operator must keep server-side resources consistent with the running brokers.
+Rejected.
 
 ### Pin node ports deterministically
 
-Giving `nodeport` listeners stable, formula-derived node ports (so a type change/rollback never reshuffles ports between listeners) was considered. It only narrows Failure mode B for one listener type (`nodeport`) and does nothing for Failure mode A or for `loadbalancer`/`cluster-ip`/`route`/`ingress`, so it is not a general fix. It is also inflexible: formula-derived ports must fit within the cluster's `service-node-port-range`, can collide with other `NodePort` services, and pin the operator to a fixed allocation scheme. Per-broker reconciliation addresses the root cause for all listener types instead. Rejected.
+Giving `nodeport` listeners stable, formula-derived node ports (so a type change or rollback never reshuffles ports between listeners) was considered.
+It only narrows Failure mode B for one listener type (`nodeport`) and does nothing for Failure mode A or for `loadbalancer`, `cluster-ip`, `route`, and `ingress`, so it is not a general fix.
+It is also inflexible: formula-derived ports must fit within the cluster's `service-node-port-range`, can collide with other `NodePort` services, and pin the operator to a fixed allocation scheme.
+Per-broker reconciliation addresses the root cause for all listener types instead.
+Rejected.

--- a/148-safe-listener-connectivity-rollout.md
+++ b/148-safe-listener-connectivity-rollout.md
@@ -1,11 +1,13 @@
-# Safe rollout of listener connectivity changes (per-broker listener-resource reconciliation + deterministic node ports)
+# Safe rollout of listener connectivity changes
 
 Make connectivity-affecting listener changes (listener type changes, port changes, adding/removing a listener) safe to roll out and roll back. This applies to **all listener types that provision per-broker Kubernetes resources** — `nodeport`, `loadbalancer`, `cluster-ip`, `route`, and `ingress` — not just `nodeport`. The proposal has two complementary parts:
 
 - **Per-broker listener-resource reconciliation aligned with the rolling update (the general fix).** Reconcile each broker's listener resources (its `Service`, and `Route`/`Ingress` where applicable) in lockstep with that broker's own restart, instead of replacing all per-broker resources for the whole cluster up front while the brokers restart one by one. This removes the availability window — present for **every** per-broker listener type — where a not-yet-rolled broker's resources already point at a listener the broker is not yet serving.
 - **Deterministic node ports (a `nodeport`-specific hardening).** Give `nodeport` listeners stable, formula-derived node ports so deployments and rollbacks never reshuffle ports between listeners. This removes the most severe failure from the incident below (clients hitting the *wrong SASL mechanism*), with a small, low-risk change and no change to the rolling-update machinery.
 
-The two are independent and can ship separately. The rest of this document refers to them as **Phase 1 (deterministic node ports)** and **Phase 2 (per-broker reconciliation)**, numbered by expected delivery order (Phase 1 is the smaller change and is expected to land first), not by importance — Phase 2 is the general fix.
+The rest of this document refers to them as **Phase 1 (deterministic node ports)** and **Phase 2 (per-broker reconciliation)**, numbered by expected delivery order (Phase 1 is the smaller change and is expected to land first), not by importance — Phase 2 is the general fix.
+
+**Why a single proposal.** The two parts are the two independent root causes of the *same* incident and are designed against the same area of the code (external listener provisioning during a roll); presenting them together makes the trade-off between them explicit (see [Rejected alternatives](#rejected-alternatives), which shows why neither alone is sufficient). They can still be delivered as **two separate pull requests** — Phase 1 is a self-contained CRD feature with no dependency on Phase 2 — and if the maintainers prefer, Phase 1 can be extracted into its own proposal. The implementation work is intentionally decoupled; only the design rationale is shared.
 
 `loadbalancer` listeners have an address-churn problem analogous to the `nodeport` port reshuffle (the cloud may reassign the external IP/hostname when the `Service` is recreated); equivalent pinning mitigations exist but are cloud-provider-specific and are out of scope here. The general remedy for `loadbalancer` (and all other types) is Phase 2.
 
@@ -103,6 +105,13 @@ listeners:
 ```
 
 Because each listener maps to a disjoint port range and each broker's port is a pure function of its node ID, ports are identical across every deploy, rollback and type change, and two listeners can never collide. Node-port validation is extended to reject rendered values outside the service node-port range and duplicates within a listener.
+
+**Relationship to `advertisedPortTemplate` (#135).** These are different fields controlling different things and are not interchangeable:
+
+- `advertisedPortTemplate` sets the **advertised** port — the value Strimzi writes into `advertised.listeners` and hands to clients. It does **not** influence which `NodePort` Kubernetes actually allocates.
+- `nodePortTemplate` (this proposal) pins the **actually allocated** `spec.ports[].nodePort` on the `Service`. This is the value that physically routes traffic and that collides on a random reallocation.
+
+For a `nodeport` listener the two are normally equal, but only pinning the real `NodePort` prevents the collision; templating only the advertised port would still let Kubernetes shuffle the underlying ports. `nodePortTemplate` follows the same formula syntax and evaluation as `advertisedPortTemplate` for consistency.
 
 Phase 1 requires no change to the rolling update and is fully backwards compatible (explicit per-broker `nodePort` continues to take precedence). It can be delivered and adopted before Phase 2.
 
@@ -204,9 +213,12 @@ The roll iterates node by node on a single-threaded executor via `maybeRollKafka
 The hook (`reconcileBrokerListener(node)` + that broker's `ConfigMap` update) must:
 
 - fire only at those points, never when a node is merely "considered" (otherwise the broker's resources are switched while the still-running broker serves the old listener — the exact bug, localized to one broker for the duration of a deferral);
-- be **idempotent**, because a node may pass `canRoll` and still be retried.
+- be **idempotent**, because a node may pass `canRoll` and still be retried;
+- run before **every** restart of a not-yet-converged broker, including the `forceRestart` and force-roll-on-error branches (see below).
 
-A connectivity change is signalled by `podNeedsRestart` returning a new reason (e.g. `LISTENER_CONFIGURATION_CHANGE`) for brokers that are not yet converged. This yields `needsRestart = true` (so it is gated by `canRoll` and never the unsafe `forceRestart`) and short-circuits the dynamic-reconfiguration path (`advertised.listeners` is not dynamically updatable anyway).
+A connectivity change is signalled by `podNeedsRestart` returning a new reason (e.g. `LISTENER_CONFIGURATION_CHANGE`) for brokers that are not yet converged. This yields `needsRestart = true` (so it is gated by `canRoll`) and short-circuits the dynamic-reconfiguration path (`advertised.listeners` is not dynamically updatable anyway).
+
+**Handling the `forceRestart` branch.** Although a connectivity change itself maps to `needsRestart` (not `forceRestart`), a not-yet-converged broker can still hit the `forceRestart`/force-roll-on-error path for an *unrelated* reason — e.g. the pod is stuck, unresponsive, or on an old revision — during the migration. If the listener hook only ran on the `needsRestart` branch, such a broker would be restarted with its resources/`ConfigMap` still on the old listener and would come back mismatched, converging only on a later reconcile. The hook must therefore key off "is this broker not yet converged?" and run before the restart on **all** branches. Because the hook is idempotent and only reconciles that broker's own resources, doing so on the force paths is safe.
 
 **4. Avoid the PodSet "double-roll".**
 The advertised host/port hash is folded into the broker config hash and surfaced as a **pod annotation** (`perBrokerKafkaConfiguration()` → `podSetPodAnnotations()`), and `podSet()` runs *before* the roll and can itself restart pods when annotations change. If the new advertised config were applied up front, `podSet()` would roll pods prematurely — with the new annotation but before the per-broker `Service` hook runs. Phase 2 must therefore keep the up-front `podSet()` carrying the **old** advertised hash and apply each broker's new config/annotation during the roll (step 3), so a broker is rolled exactly once, by `KafkaRoller`, with its `Service` already switched. This is the most delicate part of the implementation and must be covered by tests.
@@ -233,11 +245,32 @@ reconcileSharedPrerequisites()        // certs/secrets, no connectivity change
 - If a broker fails to roll, the bootstrap is never switched; the cluster is left in a still-functional mixed state (each broker self-consistent) and the next reconcile resumes via the per-broker convergence guard.
 - `KafkaRoller`'s existing controller/quorum and in-sync-replica safety checks are unchanged and continue to gate each broker's restart.
 
-### Implementation alternative considered for Phase 2
+### Decision: in-roller hook (and the rejected alternative)
 
-Rather than teaching `KafkaRoller` to reconcile listener resources, the listener reconciler could drive the roll itself by calling `maybeRollKafka(...)` with a **single-node set per broker**, reconciling that broker's resources between calls. This keeps resource/`ConfigMap` I/O out of `KafkaRoller` and preserves its clean "pods + admin client only" boundary, which is attractive for the operator's most safety-critical component.
+**This proposal recommends the in-roller hook** described above: a single `KafkaRoller` instance for the whole roll, with the strictly-placed, idempotent pre-restart hook reconciling each broker's resources.
 
-The downside is real: a fresh `KafkaRoller` per broker loses the cross-node ordering and quorum/ISR batching that a single roller instance provides across all nodes, re-creates admin clients on every call, and re-derives ordering (controllers vs brokers, unready-first) that the roller does for free. Given those losses, this proposal recommends the in-roller hook (with the strict pre-restart placement above) as the primary approach, but the per-broker-`maybeRollKafka` variant is a viable fallback if maintainers prefer not to widen the `KafkaRoller` boundary, and the choice should be settled during review.
+The decision is driven by **safety over boundary-cleanliness**. A single `KafkaRoller` instance holds the cluster-wide view needed to roll safely — controller-first ordering, unready-first ordering, and quorum/ISR `canRoll` checks evaluated across all nodes. Preserving that global view is the property that actually protects availability during the roll, and it is the harder thing to get right.
+
+The rejected alternative is to drive the roll from the listener reconciler by calling `maybeRollKafka(...)` with a **single-node set per broker**, reconciling that broker's resources between calls. This keeps resource/`ConfigMap` I/O out of `KafkaRoller` and preserves its clean "pods + admin client only" boundary — attractive, but it spins up a fresh roller per broker, which loses the cross-node ordering and quorum/ISR batching, re-creates admin clients on every call, and re-derives ordering the roller otherwise does for free. Trading away the roller's global safety reasoning to keep a code boundary tidy is the wrong trade for the operator's most safety-critical path, so this variant is rejected. The cost of the chosen approach — widening `KafkaRoller`'s responsibility — is contained by the strict hook placement and idempotency requirements above and must be covered by tests.
+
+### Feature gate and rollout (Phase 2)
+
+Because Phase 2 changes the behaviour of the reconcile/roll path — the operator's most safety-critical area — it is introduced behind a **feature gate** (e.g. `CoupledListenerRollout`), following Strimzi's usual gate lifecycle:
+
+- **Alpha (disabled by default):** opt-in for early adopters and CI; the current all-at-once behaviour remains the default.
+- **Beta (enabled by default):** after the test matrix below is green across supported listener types, with the gate still available to disable.
+- **GA / gate removal:** once proven in the field.
+
+When the gate is disabled, the code path is exactly today's behaviour, so the change is risk-free to ship dark.
+
+### Testing (Phase 2)
+
+The proposal is only credible with explicit coverage of the partial-roll states it claims to make safe:
+
+- **Unit tests** for the per-broker convergence detector (mixed/half-migrated state, internal-listener guard) and for the `KafkaRoller` hook placement (fires only pre-restart after `canRoll`, fires on the `forceRestart`/error branches for not-yet-converged brokers, is idempotent under retries, does not fire for "considered-but-deferred" nodes).
+- **Integration tests** asserting no PodSet "double-roll" occurs (each broker rolls exactly once for a connectivity change).
+- **System tests** that perform a listener `type` change and a rollback for each per-broker listener type (`nodeport`, `loadbalancer`, `cluster-ip`, `route`, `ingress`) on a multi-broker cluster, asserting clients with cached metadata keep producing/consuming throughout the roll, and that an interrupted reconcile resumes rather than re-rolling.
+- **Phase 1** adds validation tests for `nodePortTemplate` (range/duplicate rejection, formula evaluation, precedence over and interaction with explicit `nodePort`).
 
 ## Affected/not affected projects
 
@@ -250,6 +283,7 @@ No other Strimzi projects are affected. Only KRaft-based clusters are in scope (
 
 ## Compatibility
 
+- **Phase 2 is gated** behind a feature gate that is disabled by default initially (see [Feature gate and rollout (Phase 2)](#feature-gate-and-rollout-phase-2)), so it ships with zero behaviour change until explicitly enabled.
 - **Behaviour is unchanged for non-connectivity-affecting reconciliations**, and for connectivity changes on internal listeners (which fall back to current behaviour).
 - **Phase 1 is fully backwards compatible**: `nodePortTemplate` is optional and explicit per-broker `nodePort` still wins.
 - **Phase 2 needs no API/CRD change.**

--- a/148-safe-listener-connectivity-rollout.md
+++ b/148-safe-listener-connectivity-rollout.md
@@ -1,15 +1,10 @@
 # Safe rollout of listener connectivity changes
 
-Make connectivity-affecting listener changes (listener type changes, port changes, adding/removing a listener) safe to roll out and roll back. This applies to **all listener types that provision per-broker Kubernetes resources** — `nodeport`, `loadbalancer`, `cluster-ip`, `route`, and `ingress` — not just `nodeport`. The proposal has two complementary parts:
+Make connectivity-affecting listener changes (listener type changes, port changes, adding/removing a listener) safe to roll out and roll back, for **all listener types that provision per-broker Kubernetes resources** — `nodeport`, `loadbalancer`, `cluster-ip`, `route`, and `ingress`.
 
-- **Per-broker listener-resource reconciliation aligned with the rolling update (the general fix).** Reconcile each broker's listener resources (its `Service`, and `Route`/`Ingress` where applicable) in lockstep with that broker's own restart, instead of replacing all per-broker resources for the whole cluster up front while the brokers restart one by one. This removes the availability window — present for **every** per-broker listener type — where a not-yet-rolled broker's resources already point at a listener the broker is not yet serving.
-- **Deterministic node ports (a `nodeport`-specific hardening).** Give `nodeport` listeners stable, formula-derived node ports so deployments and rollbacks never reshuffle ports between listeners. This removes the most severe failure from the incident below (clients hitting the *wrong SASL mechanism*), with a small, low-risk change and no change to the rolling-update machinery.
+The proposal reconciles each broker's listener resources (its `Service`, and `Route`/`Ingress` where applicable) **in lockstep with that broker's own restart**, instead of replacing all per-broker resources for the whole cluster up front while the brokers restart one by one. This removes the availability window — present for every per-broker listener type — where a not-yet-rolled broker's resources already point at a listener the broker is not yet serving.
 
-This document refers to them as **Phase 1 (deterministic node ports)** and **Phase 2 (per-broker reconciliation)**. They are independent and can be delivered as separate pull requests; Phase 2 is the general fix.
-
-`loadbalancer` listeners have an address-churn problem analogous to the `nodeport` port reshuffle (the cloud may reassign the external IP/hostname when the `Service` is recreated); equivalent pinning mitigations exist but are cloud-provider-specific and are out of scope here. The general remedy for `loadbalancer` (and all other types) is Phase 2.
-
-> **Scope: KRaft only.** This proposal assumes KRaft-based Kafka clusters and does not consider ZooKeeper-based clusters (ZooKeeper support has been removed from current Strimzi). The Phase 2 partial-roll correctness argument relies on KRaft broker-registration semantics (see [KRaft assumption](#kraft-assumption)).
+> **Scope: KRaft only.** This proposal assumes KRaft-based Kafka clusters and does not consider ZooKeeper-based clusters (ZooKeeper support has been removed from current Strimzi). The partial-roll correctness argument relies on KRaft broker-registration semantics (see [KRaft assumption](#kraft-assumption)).
 
 ## Current situation
 
@@ -35,22 +30,9 @@ When the listener **type** changes (for example `nodeport` → `cluster-ip` or a
 
 #### Failure mode B — address churn on resource recreate (`nodeport` and `loadbalancer`)
 
-Some listener types do not have a stable externally-visible address across a resource recreate:
+Some listener types do not have a stable externally-visible address across a resource recreate: a `nodeport` `Service`'s node port is preserved only when the old and new `Service` are both already `NodePort`, so across a **type change** Kubernetes allocates fresh random ports on the way back to `NodePort`; a `loadbalancer` `Service` may get a new external IP/hostname on recreate. Combined with Failure mode A, the consequence can be severe: a port that previously fronted one listener may be reallocated to a *different* listener, so a client with cached metadata that cannot refresh (because the rest of the cluster is unreachable mid-roll) sends, for example, a SCRAM handshake to a port now serving the Kerberos listener — an authentication-protocol mismatch.
 
-- For `nodeport`, the `spec.ports[].nodePort` is normally assigned randomly by Kubernetes from the service node-port range. `ServiceOperator.patchNodePorts` only preserves it when the current and desired `Service` are **both** already `NodePort` (or both `LoadBalancer`):
-
-```java
-// ServiceOperator.internalUpdate(...)
-if (("NodePort".equals(current.getSpec().getType()) && "NodePort".equals(desired.getSpec().getType()))
-        || ("LoadBalancer".equals(current.getSpec().getType()) && "LoadBalancer".equals(desired.getSpec().getType())))   {
-    patchNodePorts(current, desired);
-```
-
-So across a **type change** the old port cannot be preserved and Kubernetes allocates fresh random ports on the way back to `NodePort`. The severe consequence is **cross-listener collision**: random reallocation can move a port that previously fronted one listener onto a *different* listener, so a client with cached metadata sends, say, a SCRAM handshake to a port now serving the Kerberos listener — a hard authentication-protocol mismatch that does not self-heal.
-
-- For `loadbalancer`, the cloud may assign a new external IP/hostname when the `Service` is recreated, so cached clients target an address that no longer exists.
-
-`cluster-ip`, `route`, and `ingress` addresses are normally derived deterministically from resource names, so they suffer Failure mode A but not B.
+`cluster-ip`, `route`, and `ingress` addresses are derived deterministically from resource names, so they suffer Failure mode A but not B.
 
 ### Incident this addresses
 
@@ -65,54 +47,16 @@ Client SASL mechanism 'GSSAPI' not enabled in the server, enabled mechanisms are
 ```
 
 Reads and writes failed cluster-wide for ~3 hours and only recovered after every broker pod was deleted to force a full, consistent reconcile.
-The port collision was the proximate cause of the sustained auth failures; the all-at-once `Service` switch extended the unavailability across the whole roll.
 
 ## Motivation
 
-Failure modes A and B are independent root causes: A is general to every per-broker listener type, while B is specific to the address assignment of `nodeport` (and `loadbalancer`). They are orthogonal, so neither fix alone is sufficient. The proposal therefore addresses both — Phase 2 couples per-broker resource reconciliation to the roll (the general fix for A), and Phase 1 pins node ports to remove the severe `nodeport` collision (B).
+The root cause is an **atomicity mismatch**: listener resources are switched atomically for the whole cluster, but the brokers that back those resources converge gradually as they restart one by one. During that window every not-yet-rolled broker advertises a listener it is not yet serving, so clients fail to connect; and because most of the cluster is unreachable, clients cannot refresh their metadata to recover. On `nodeport`/`loadbalancer` the same window is what makes a port/address reshuffle dangerous (Failure mode B): without a reachable cluster to refresh from, cached clients keep hitting stale — and possibly cross-wired — endpoints.
+
+Reconciling each broker's listener resources in lockstep with that broker's own restart removes the window: at every instant each broker is internally consistent (its resources match the listener it is running), so the change rolls through the cluster the same safe way a normal restart does, and clients can always refresh metadata against the parts of the cluster that are still up.
 
 ## Proposal
 
-### Phase 1 — Deterministic node ports
-
-Provide a way to assign every broker (and the bootstrap) of a `nodeport` listener a **stable, deterministic** node port that does not depend on `Service` create/delete ordering or type changes.
-
-Strimzi already supports pinning node ports statically per broker (`configuration.bootstrap.nodePort`, `configuration.brokers[].nodePort`), but enumerating hundreds of brokers across two listeners is impractical and error-prone, and the node IDs must be known up front (awkward with KRaft/node pools). A formula-based template — mirroring the existing `advertisedPortTemplate` (Proposal #135) — removes that limitation, e.g.:
-
-```yaml
-listeners:
-  - name: scram
-    port: 9096
-    type: nodeport
-    tls: true
-    authentication:
-      type: scram-sha-512
-    configuration:
-      nodePortTemplate: 30000 + {nodeId}
-  - name: kerberos
-    port: 9097
-    type: nodeport
-    tls: true
-    configuration:
-      nodePortTemplate: 31000 + {nodeId}
-```
-
-Because each listener maps to a disjoint port range and each broker's port is a pure function of its node ID, ports are identical across every deploy, rollback and type change, and two listeners can never collide. Node-port validation is extended to reject rendered values outside the service node-port range and duplicates within a listener.
-
-**Relationship to `advertisedPortTemplate` (#135).** These are different fields controlling different things and are not interchangeable:
-
-- `advertisedPortTemplate` sets the **advertised** port — the value Strimzi writes into `advertised.listeners` and hands to clients. It does **not** influence which `NodePort` Kubernetes actually allocates.
-- `nodePortTemplate` (this proposal) pins the **actually allocated** `spec.ports[].nodePort` on the `Service`. This is the value that physically routes traffic and that collides on a random reallocation.
-
-For a `nodeport` listener the two are normally equal, but only pinning the real `NodePort` prevents the collision; templating only the advertised port would still let Kubernetes shuffle the underlying ports. `nodePortTemplate` follows the same formula syntax and evaluation as `advertisedPortTemplate` for consistency.
-
-Phase 1 requires no change to the rolling update and is fully backwards compatible (explicit per-broker `nodePort` continues to take precedence). It can be delivered and adopted before Phase 2.
-
-### Phase 2 — Per-broker listener-resource reconciliation aligned with the rolling update
-
-This is the general fix and applies to **all per-broker listener types** (`nodeport`, `loadbalancer`, `cluster-ip`, `route`, `ingress`).
-
-When a reconciliation includes a **connectivity-affecting listener change**, reconcile the per-broker listener resources (the broker's `Service`, and its `Route`/`Ingress` where applicable) as part of the rolling update, broker by broker, instead of all at once before the roll. Then, at every instant, each broker's resources match the listener that broker is actually running, and the change rolls through the cluster the same safe way a normal restart does.
+When a reconciliation includes a **connectivity-affecting listener change**, reconcile the per-broker listener resources (the broker's `Service`, and its `Route`/`Ingress` where applicable) as part of the rolling update, broker by broker, instead of all at once before the roll.
 
 A change is "connectivity-affecting" when it changes what a client must connect to:
 
@@ -122,7 +66,7 @@ A change is "connectivity-affecting" when it changes what a client must connect 
 
 All other reconciliations (config-only changes, certificate rotations, image upgrades, scaling, etc.) keep the current behaviour unchanged.
 
-#### Precondition: the internal listeners are never part of the change
+### Precondition: the internal listeners are never part of the change
 
 The rolling update's safety checks (quorum / in-sync-replica `canRoll`) depend on the operator's admin client, which connects over the **internal** replication and control-plane listeners (the headless `brokers` service on `REPLICATION_PORT` / `CONTROLPLANE_PORT`), not the external listener being changed:
 
@@ -133,28 +77,28 @@ bootstrapHostnames = nodes.stream().filter(NodeRef::broker)
     .collect(Collectors.joining(","));
 ```
 
-This is exactly what makes Phase 2 safe: the external listener can be in flux while the operator still reaches the cluster for availability checks. The coupled path is therefore valid **only for external/client listeners**; a change to the internal replication/control listener cannot use this mechanism and must fall back to the current behaviour (or be disallowed). The detector must guard for this.
+This is exactly what makes the approach safe: the external listener can be in flux while the operator still reaches the cluster for availability checks. The coupled path is therefore valid **only for external/client listeners**; a change to the internal replication/control listener cannot use this mechanism and must fall back to the current behaviour (or be disallowed). The detector must guard for this.
 
-#### Per-broker convergence guard (idempotency)
+### Per-broker convergence guard (idempotency)
 
 Reconciliations can be interrupted and re-run, leaving the cluster half-migrated (some brokers new, some old). The "connectivity change" decision must therefore be evaluated **per broker** — "do this broker's observed listener resources already match the desired listener config?" — not as a single cluster-global flag. Brokers already at the desired state are skipped, so a re-run resumes the migration instead of re-rolling the whole cluster. This makes the operation convergent and resumable.
 
-#### Per-broker rollout loop
+### Per-broker rollout loop
 
 For each broker that is not yet converged, in the order and under the safety gates the existing roll already enforces:
 
-1. Reconcile **that broker's** listener resource(s) — `Service`, and `Route`/`Ingress` where applicable — to the desired state (create/update/delete). For types whose externally-visible address is assigned asynchronously, wait until it is available for that broker: the assigned `nodePort` (`nodeport`, deterministic with Phase 1), the load-balancer ingress IP/hostname (`loadbalancer`), or the admitted host (`route`). `cluster-ip`/`ingress` addresses are deterministic and need no wait.
+1. Reconcile **that broker's** listener resource(s) — `Service`, and `Route`/`Ingress` where applicable — to the desired state (create/update/delete). For types whose externally-visible address is assigned asynchronously, wait until it is available for that broker: the assigned `nodePort` (`nodeport`), the load-balancer ingress IP/hostname (`loadbalancer`), or the admitted host (`route`). `cluster-ip`/`ingress` addresses are deterministic and need no wait.
 2. Render **that broker's** configuration with the resulting `advertised.listeners` and apply its `ConfigMap`.
 3. Restart the broker so it starts serving the new listener and re-registers its advertised endpoint.
 4. Wait until the broker is ready before moving to the next broker.
 
-#### Bootstrap resource
+### Bootstrap resource
 
 The bootstrap resource is shared (one `Service`/`Route`/`Ingress` for the whole listener) and is reconciled **last**, after all brokers have rolled.
 This avoids switching the shared entry point until the per-broker endpoints behind it are all consistent, and makes the bootstrap change a single, fast operation at the end.
 Note this does **not** guarantee a *reachable* bootstrap throughout the roll: if the bootstrap's current state is itself part of the change (e.g. mid-rollback it is still the wrong type), clients doing a cold start or metadata refresh *through the bootstrap* recover only once it flips at the end. Clients holding cached per-broker metadata are unaffected (see below).
 
-#### Availability during a partial roll
+### Availability during a partial roll
 
 A half-rolled cluster does **not** cause widespread failure for clients with cached metadata; it degrades to an ordinary rolling restart.
 
@@ -164,6 +108,8 @@ For any partition, such a client connects to the leader's currently-advertised a
 - leader on a not-yet-rolled broker → metadata gives the old address, the old resource still exists → works;
 - leader on the broker currently restarting → brief unavailability while leadership fails over to an in-sync replica, covered by normal client retries (RF ≥ 2).
 
+This also bounds the impact of address churn (Failure mode B). Because each broker's resource is switched in lockstep with its restart and the rest of the cluster stays reachable, a client targeting a stale `nodeport`/`loadbalancer` address simply refreshes its metadata and connects to that broker's current address. A reshuffled or cross-wired port affects at most one broker momentarily and is self-healed by a metadata refresh — instead of the sustained, cluster-wide outage that occurs today when the whole cluster is switched at once and clients cannot refresh.
+
 Remaining failure modes are the ordinary ones, not new to this change:
 
 - **RF = 1 topics**: partitions led by the broker currently restarting are unavailable until it returns (true for any restart).
@@ -172,7 +118,7 @@ Remaining failure modes are the ordinary ones, not new to this change:
 
 This is fundamentally different from the current behaviour, where a not-yet-rolled broker's mismatched resources fail *all* connections to it for the *entire* roll.
 
-#### KRaft assumption
+### KRaft assumption
 
 The partial-roll correctness argument depends on KRaft semantics and applies to **KRaft-based clusters only**:
 
@@ -182,7 +128,7 @@ The partial-roll correctness argument depends on KRaft semantics and applies to 
 
 ZooKeeper-based clusters are explicitly out of scope.
 
-### Implementation sketch (Phase 2)
+### Implementation sketch
 
 The change is an ordering/wiring change in the Cluster Operator; the building blocks already exist.
 
@@ -214,7 +160,7 @@ A connectivity change is signalled by `podNeedsRestart` returning a new reason (
 **Handling the `forceRestart` branch.** Although a connectivity change itself maps to `needsRestart` (not `forceRestart`), a not-yet-converged broker can still hit the `forceRestart`/force-roll-on-error path for an *unrelated* reason — e.g. the pod is stuck, unresponsive, or on an old revision — during the migration. If the listener hook only ran on the `needsRestart` branch, such a broker would be restarted with its resources/`ConfigMap` still on the old listener and would come back mismatched, converging only on a later reconcile. The hook must therefore key off "is this broker not yet converged?" and run before the restart on **all** branches. Because the hook is idempotent and only reconciles that broker's own resources, doing so on the force paths is safe.
 
 **4. Avoid the PodSet "double-roll".**
-The advertised host/port hash is folded into the broker config hash and surfaced as a **pod annotation** (`perBrokerKafkaConfiguration()` → `podSetPodAnnotations()`), and `podSet()` runs *before* the roll and can itself restart pods when annotations change. If the new advertised config were applied up front, `podSet()` would roll pods prematurely — with the new annotation but before the per-broker `Service` hook runs. Phase 2 must therefore keep the up-front `podSet()` carrying the **old** advertised hash and apply each broker's new config/annotation during the roll (step 3), so a broker is rolled exactly once, by `KafkaRoller`, with its `Service` already switched. This is the most delicate part of the implementation and must be covered by tests.
+The advertised host/port hash is folded into the broker config hash and surfaced as a **pod annotation** (`perBrokerKafkaConfiguration()` → `podSetPodAnnotations()`), and `podSet()` runs *before* the roll and can itself restart pods when annotations change. If the new advertised config were applied up front, `podSet()` would roll pods prematurely — with the new annotation but before the per-broker resource hook runs. The implementation must therefore keep the up-front `podSet()` carrying the **old** advertised hash and apply each broker's new config/annotation during the roll (step 3), so a broker is rolled exactly once, by `KafkaRoller`, with its resources already switched. This is the most delicate part of the implementation and must be covered by tests.
 
 **5. Reconcile the bootstrap last**, then populate listener status.
 
@@ -246,9 +192,9 @@ The decision is driven by **safety over boundary-cleanliness**. A single `KafkaR
 
 The rejected alternative is to drive the roll from the listener reconciler by calling `maybeRollKafka(...)` with a **single-node set per broker**, reconciling that broker's resources between calls. This keeps resource/`ConfigMap` I/O out of `KafkaRoller` and preserves its clean "pods + admin client only" boundary — attractive, but it spins up a fresh roller per broker, which loses the cross-node ordering and quorum/ISR batching, re-creates admin clients on every call, and re-derives ordering the roller otherwise does for free. Trading away the roller's global safety reasoning to keep a code boundary tidy is the wrong trade for the operator's most safety-critical path, so this variant is rejected. The cost of the chosen approach — widening `KafkaRoller`'s responsibility — is contained by the strict hook placement and idempotency requirements above and must be covered by tests.
 
-### Feature gate and rollout (Phase 2)
+### Feature gate and rollout
 
-Because Phase 2 changes the behaviour of the reconcile/roll path — the operator's most safety-critical area — it is introduced behind a **feature gate** (e.g. `CoupledListenerRollout`), following Strimzi's usual gate lifecycle:
+Because this changes the behaviour of the reconcile/roll path — the operator's most safety-critical area — it is introduced behind a **feature gate** (e.g. `CoupledListenerRollout`), following Strimzi's usual gate lifecycle:
 
 - **Alpha (disabled by default):** opt-in for early adopters and CI; the current all-at-once behaviour remains the default.
 - **Beta (enabled by default):** after the test matrix below is green across supported listener types, with the gate still available to disable.
@@ -256,47 +202,38 @@ Because Phase 2 changes the behaviour of the reconcile/roll path — the operato
 
 When the gate is disabled, the code path is exactly today's behaviour, so the change is risk-free to ship dark.
 
-### Testing (Phase 2)
+### Testing
 
 The proposal is only credible with explicit coverage of the partial-roll states it claims to make safe:
 
 - **Unit tests** for the per-broker convergence detector (mixed/half-migrated state, internal-listener guard) and for the `KafkaRoller` hook placement (fires only pre-restart after `canRoll`, fires on the `forceRestart`/error branches for not-yet-converged brokers, is idempotent under retries, does not fire for "considered-but-deferred" nodes).
 - **Integration tests** asserting no PodSet "double-roll" occurs (each broker rolls exactly once for a connectivity change).
 - **System tests** that perform a listener `type` change and a rollback for each per-broker listener type (`nodeport`, `loadbalancer`, `cluster-ip`, `route`, `ingress`) on a multi-broker cluster, asserting clients with cached metadata keep producing/consuming throughout the roll, and that an interrupted reconcile resumes rather than re-rolling.
-- **Phase 1** adds validation tests for `nodePortTemplate` (range/duplicate rejection, formula evaluation, precedence over and interaction with explicit `nodePort`).
 
 ## Affected/not affected projects
 
-This proposal affects the **Strimzi Cluster Operator** only:
+This proposal affects the **Strimzi Cluster Operator** only: `KafkaReconciler` (reconcile ordering), `KafkaListenersReconciler` (split into shared / per-broker / bootstrap reconciliation), and `KafkaRoller` (a strictly-placed, idempotent pre-restart hook and just-in-time advertised host/port supply).
 
-- Phase 1: the `api` module (a `nodePortTemplate` field on the listener configuration), `ListenersValidator`, `ListenersUtils`/`ServiceUtils` rendering, plus CRD/examples/docs.
-- Phase 2: `KafkaReconciler` (reconcile ordering), `KafkaListenersReconciler` (split into shared / per-broker / bootstrap reconciliation), and `KafkaRoller` (a strictly-placed, idempotent pre-restart hook and just-in-time advertised host/port supply).
-
-No other Strimzi projects are affected. Only KRaft-based clusters are in scope (see [KRaft assumption](#kraft-assumption)).
+No CRD/API changes are required. No other Strimzi projects are affected. Only KRaft-based clusters are in scope (see [KRaft assumption](#kraft-assumption)).
 
 ## Compatibility
 
-- **Phase 2 is gated** behind a feature gate that is disabled by default initially (see [Feature gate and rollout (Phase 2)](#feature-gate-and-rollout-phase-2)), so it ships with zero behaviour change until explicitly enabled.
+- **Gated** behind a feature gate that is disabled by default initially (see [Feature gate and rollout](#feature-gate-and-rollout)), so it ships with zero behaviour change until explicitly enabled.
 - **Behaviour is unchanged for non-connectivity-affecting reconciliations**, and for connectivity changes on internal listeners (which fall back to current behaviour).
-- **Phase 1 is fully backwards compatible**: `nodePortTemplate` is optional and explicit per-broker `nodePort` still wins.
-- **Phase 2 needs no API/CRD change.**
+- **No API/CRD change.**
 - **Reconciliation takes longer** for connectivity-affecting changes, because per-broker resource reconciliation (and waiting for an asynchronously-assigned address) is interleaved with the roll. This is most pronounced for `loadbalancer`, where each per-broker LB is provisioned by the cloud (often minutes) and is now serialized across the roll; for large clusters (200+ brokers) the total can be very large. Per-broker waits are bounded by `operationTimeoutMs`, but the overall reconcile may approach or exceed the reconciliation interval, so overlap/lock behaviour and progress logging must be considered. The migration is resumable (per-broker convergence guard), so an aborted reconcile continues on the next pass rather than restarting from scratch.
 - **Listener status** is fully populated only after the roll completes; intermediate reconcile passes may report a mix of old and new per-broker addresses, all valid at the time.
 
 ## Rejected alternatives
 
-### Roll all `Service`s, then delete all pods at once
+### Roll all resources, then delete all pods at once
 
 Forcing a full, simultaneous pod restart (as was done manually to recover the incident) makes the cluster consistent quickly but causes a hard, total outage during the restart and defeats the purpose of rolling updates. Rejected.
 
 ### Make clients tolerate the mismatch
 
-Relying on client-side retry/metadata-refresh tuning to ride out the window does not work when the `Service` actively fronts the *wrong* listener (auth-mechanism mismatch) or the port no longer exists for a sustained period. The operator must keep server-side `Service`s consistent with the running brokers. Rejected.
+Relying on client-side retry/metadata-refresh tuning to ride out the window does not work when the resource actively fronts the *wrong* listener (auth-mechanism mismatch) or the address no longer exists for a sustained period. The operator must keep server-side resources consistent with the running brokers. Rejected.
 
-### Phase 1 only (deterministic ports, keep all-`Service`s-at-once)
+### Pin node ports deterministically
 
-Stable node ports eliminate the severe collision/auth-mismatch but leave the availability window where a not-yet-rolled broker's `Service` already advertises a listener it is not yet serving (e.g. on a `nodeport` ↔ `cluster-ip` type change). Acceptable as a first step and shippable on its own, but not a complete fix — hence Phase 2.
-
-### Phase 2 only (coupling, keep random ports)
-
-Coupling removes the availability window but, without stable ports, a `nodeport` type change still re-allocates random ports, so a client momentarily targeting the old port of a just-rolled broker can still transiently hit a colliding listener before refreshing metadata. Stable ports make per-broker port changes deterministic and collision-free, so Phase 1 remains worthwhile even with Phase 2. Rejected as a standalone solution.
+Giving `nodeport` listeners stable, formula-derived node ports (so a type change/rollback never reshuffles ports between listeners) was considered as a complementary `nodeport`-specific hardening; it is split into a separate proposal and out of scope here.

--- a/148-safe-listener-connectivity-rollout.md
+++ b/148-safe-listener-connectivity-rollout.md
@@ -222,4 +222,4 @@ Relying on client-side retry/metadata-refresh tuning to ride out the window does
 
 ### Pin node ports deterministically
 
-Giving `nodeport` listeners stable, formula-derived node ports (so a type change/rollback never reshuffles ports between listeners) was considered as a complementary `nodeport`-specific hardening; it is split into a separate proposal and out of scope here.
+Giving `nodeport` listeners stable, formula-derived node ports (so a type change/rollback never reshuffles ports between listeners) was considered. It only narrows Failure mode B for one listener type (`nodeport`) and does nothing for Failure mode A or for `loadbalancer`/`cluster-ip`/`route`/`ingress`, so it is not a general fix. It is also inflexible: formula-derived ports must fit within the cluster's `service-node-port-range`, can collide with other `NodePort` services, and pin the operator to a fixed allocation scheme. Per-broker reconciliation addresses the root cause for all listener types instead. Rejected.

--- a/148-safe-listener-connectivity-rollout.md
+++ b/148-safe-listener-connectivity-rollout.md
@@ -5,9 +5,7 @@ Make connectivity-affecting listener changes (listener type changes, port change
 - **Per-broker listener-resource reconciliation aligned with the rolling update (the general fix).** Reconcile each broker's listener resources (its `Service`, and `Route`/`Ingress` where applicable) in lockstep with that broker's own restart, instead of replacing all per-broker resources for the whole cluster up front while the brokers restart one by one. This removes the availability window — present for **every** per-broker listener type — where a not-yet-rolled broker's resources already point at a listener the broker is not yet serving.
 - **Deterministic node ports (a `nodeport`-specific hardening).** Give `nodeport` listeners stable, formula-derived node ports so deployments and rollbacks never reshuffle ports between listeners. This removes the most severe failure from the incident below (clients hitting the *wrong SASL mechanism*), with a small, low-risk change and no change to the rolling-update machinery.
 
-The rest of this document refers to them as **Phase 1 (deterministic node ports)** and **Phase 2 (per-broker reconciliation)**, numbered by expected delivery order (Phase 1 is the smaller change and is expected to land first), not by importance — Phase 2 is the general fix.
-
-**Why a single proposal.** The two parts are the two independent root causes of the *same* incident and are designed against the same area of the code (external listener provisioning during a roll); presenting them together makes the trade-off between them explicit (see [Rejected alternatives](#rejected-alternatives), which shows why neither alone is sufficient). They can still be delivered as **two separate pull requests** — Phase 1 is a self-contained CRD feature with no dependency on Phase 2 — and if the maintainers prefer, Phase 1 can be extracted into its own proposal. The implementation work is intentionally decoupled; only the design rationale is shared.
+This document refers to them as **Phase 1 (deterministic node ports)** and **Phase 2 (per-broker reconciliation)**. They are independent and can be delivered as separate pull requests; Phase 2 is the general fix.
 
 `loadbalancer` listeners have an address-churn problem analogous to the `nodeport` port reshuffle (the cloud may reassign the external IP/hostname when the `Service` is recreated); equivalent pinning mitigations exist but are cloud-provider-specific and are out of scope here. The general remedy for `loadbalancer` (and all other types) is Phase 2.
 
@@ -71,12 +69,7 @@ The port collision was the proximate cause of the sustained auth failures; the a
 
 ## Motivation
 
-Two independent weaknesses combined into the outage:
-
-- **All per-broker resources switched at once vs. brokers restarting one-by-one** caused the cluster-wide unavailability window (Failure mode A). This is general to every per-broker listener type, not specific to `nodeport`; the same outage shape can occur on a `loadbalancer`, `route`, `ingress`, or `cluster-ip` type change.
-- **Random, type-dependent node ports** caused the cross-listener collision and therefore the auth-mechanism mismatch (Failure mode B) — the part that was severe, sustained, and required a full pod delete to clear. (`loadbalancer` has the analogous IP-churn variant.)
-
-Fixing only the window (without stable ports) still leaves the severe `nodeport` collision on a type change. Fixing only the ports (without coupling) still leaves the availability window for all types. Hence the phased proposal: a general coupling fix for the window across all listener types (Phase 2), plus a cheap `nodeport` hardening that kills the worst symptom (Phase 1).
+Failure modes A and B are independent root causes: A is general to every per-broker listener type, while B is specific to the address assignment of `nodeport` (and `loadbalancer`). They are orthogonal, so neither fix alone is sufficient. The proposal therefore addresses both — Phase 2 couples per-broker resource reconciliation to the roll (the general fix for A), and Phase 1 pins node ports to remove the severe `nodeport` collision (B).
 
 ## Proposal
 
@@ -277,7 +270,7 @@ The proposal is only credible with explicit coverage of the partial-roll states 
 This proposal affects the **Strimzi Cluster Operator** only:
 
 - Phase 1: the `api` module (a `nodePortTemplate` field on the listener configuration), `ListenersValidator`, `ListenersUtils`/`ServiceUtils` rendering, plus CRD/examples/docs.
-- Phase 2: `KafkaReconciler` (reconcile ordering), `KafkaListenersReconciler` (split into shared / per-broker / bootstrap reconciliation), and `KafkaRoller` (a strictly-placed, idempotent pre-restart hook and just-in-time advertised host/port supply) — or, under the alternative, the per-broker `maybeRollKafka` driver instead of a `KafkaRoller` change.
+- Phase 2: `KafkaReconciler` (reconcile ordering), `KafkaListenersReconciler` (split into shared / per-broker / bootstrap reconciliation), and `KafkaRoller` (a strictly-placed, idempotent pre-restart hook and just-in-time advertised host/port supply).
 
 No other Strimzi projects are affected. Only KRaft-based clusters are in scope (see [KRaft assumption](#kraft-assumption)).
 

--- a/148-safe-listener-connectivity-rollout.md
+++ b/148-safe-listener-connectivity-rollout.md
@@ -7,12 +7,8 @@ This covers all listener types that provision per-broker Kubernetes resources: `
 The proposal reconciles each broker's listener resources in lockstep with that broker's own restart.
 Those resources are the broker's `Service`, plus its `Route` or `Ingress` where applicable.
 Today the operator replaces every per-broker resource for the whole cluster up front and then restarts the brokers one by one.
-Reconciling per broker removes the availability window where a not-yet-rolled broker's resources already point at a listener the broker is not yet serving.
-That window exists for every per-broker listener type.
-
-> **Scope: KRaft only.**
-> This proposal assumes KRaft-based Kafka clusters and does not cover ZooKeeper-based clusters, which have already been removed from current Strimzi.
-> The partial-roll correctness argument relies on KRaft broker-registration semantics (see [KRaft assumption](#kraft-assumption)).
+Reconciling per broker shrinks the mismatch window from the whole cluster for the duration of the roll down to one broker at a time, the same exposure as a normal rolling restart.
+This applies to every per-broker listener type.
 
 ## Current situation
 
@@ -63,9 +59,24 @@ Because most of the cluster is unreachable, clients cannot refresh their metadat
 On `nodeport` and `loadbalancer` the same window is what makes a port or address reshuffle dangerous (Failure mode B): with no reachable cluster to refresh from, cached clients keep hitting stale, and possibly cross-wired, endpoints (for example a SASL client reaching a port now serving a different mechanism).
 On a real cluster this has caused cluster-wide produce and consume failures for the entire duration of a listener type change and rollback.
 
-Reconciling each broker's listener resources in lockstep with that broker's own restart removes the window.
+Reconciling each broker's listener resources in lockstep with that broker's own restart shrinks the window to one broker at a time.
 At every instant each broker is internally consistent, because its resources match the listener it is running.
 The change then rolls through the cluster the same safe way a normal restart does, and clients can always refresh metadata against the parts of the cluster that are still up.
+This does not remove the window entirely: a client can still hit the single broker that is currently restarting, and bootstrap-only clients depend on the final bootstrap switch (see below).
+
+## Existing workaround
+
+A connectivity change can already be rolled out safely today, with no operator change, by never mutating an in-use listener:
+
+1. Add the new listener on a new port, alongside the existing one.
+2. Once the roll is complete, move clients to the new listener.
+3. Once clients have moved, remove the old listener.
+
+This avoids both failure modes, because the existing listener and its per-broker resources are never switched while in use.
+It is the recommended approach whenever the operator team controls, or can coordinate with, the clients.
+
+This proposal only helps the case where that discipline is not followed and the listener `type` or `port` is changed in place.
+Today such an in-place edit turns into a cluster-wide outage for the duration of the roll; the value here is turning that into an ordinary rolling restart, not enabling anything otherwise impossible.
 
 ## Proposal
 
@@ -147,7 +158,7 @@ This is different from the current behaviour, where a not-yet-rolled broker's mi
 
 ### KRaft assumption
 
-The partial-roll correctness argument depends on KRaft semantics and applies to KRaft-based clusters only:
+The partial-roll correctness argument depends on KRaft broker-registration semantics:
 
 - Each broker registers its own `advertised.listeners` with the KRaft controller on start-up, and the controller propagates the full set of broker endpoints to all brokers.
   A broker re-registering a new endpoint when it rolls is therefore enough for the rest of the cluster, and for client metadata, to see the change.
@@ -155,8 +166,6 @@ The partial-roll correctness argument depends on KRaft semantics and applies to 
 - Each broker's advertised address depends only on that broker's own resources, so its config can be rendered from its own resources alone, with no cross-broker dependency.
   For `nodeport` the advertised host is resolved by the pod from its scheduled node (via an env var) and only the port comes from the broker's `Service`; for `loadbalancer` the address comes from that broker's LB `Service` ingress; for `cluster-ip` from its per-broker DNS name; for `route` and `ingress` from that broker's `Route` or `Ingress` host.
 - Controller-only KRaft nodes have no client listeners and are skipped by the per-broker resource and config steps.
-
-ZooKeeper-based clusters are explicitly out of scope.
 
 ### Implementation sketch
 
@@ -242,15 +251,14 @@ The downside is that it spins up a fresh roller per broker, which loses the cros
 Giving up the roller's global safety reasoning to keep a code boundary tidy is the wrong trade for the operator's most safety-critical path, so this variant is rejected.
 The cost of the chosen approach, widening `KafkaRoller`'s responsibility, is contained by the strict hook placement and idempotency requirements above and must be covered by tests.
 
-### Feature gate and rollout
+### Rollout and the limits of gating
 
-Because this changes the reconcile and roll path, the operator's most safety-critical area, it is introduced behind a feature gate (for example `CoupledListenerRollout`), following Strimzi's usual gate lifecycle:
+A feature gate (for example `CoupledListenerRollout`) is the obvious way to ship this, following Strimzi's usual Alpha/Beta/GA lifecycle.
 
-- **Alpha (disabled by default):** opt-in for early adopters and CI; the current all-at-once behaviour remains the default.
-- **Beta (enabled by default):** after the test matrix below is green across the supported listener types, with the gate still available to disable.
-- **GA / gate removal:** once proven in the field.
-
-When the gate is disabled, the code path is exactly today's behaviour, so the change is safe to ship dark.
+It is worth being honest about how much a gate actually buys here.
+The natural off-switch is the connectivity-change detector itself: with no connectivity-affecting change, the reconcile keeps exactly today's flow.
+But the change is spread across the reconcile and roll path (`KafkaReconciler` ordering, the `KafkaListenersReconciler` split, and the `KafkaRoller` hook), so the new code sits in the common path even when the gate is off and cannot be cleanly isolated behind it.
+That limits how much risk a gate removes, and is one of the reasons this change is hard to justify for the benefit it provides.
 
 ### Testing
 
@@ -266,18 +274,17 @@ This proposal affects the Strimzi Cluster Operator only: `KafkaReconciler` (reco
 
 No CRD or API changes are required.
 No other Strimzi projects are affected.
-Only KRaft-based clusters are in scope (see [KRaft assumption](#kraft-assumption)).
+The correctness argument relies on KRaft broker registration (see [KRaft assumption](#kraft-assumption)).
 
 ## Compatibility
 
-- **Gated** behind a feature gate that is disabled by default initially (see [Feature gate and rollout](#feature-gate-and-rollout)), so it ships with zero behaviour change until explicitly enabled.
+- **Gateable, but not cleanly:** a feature gate can default the behaviour off, but the new code is spread across the reconcile and roll path and cannot be fully isolated behind it (see [Rollout and the limits of gating](#rollout-and-the-limits-of-gating)).
 - **Behaviour is unchanged** for non-connectivity-affecting reconciliations, and for connectivity changes on internal listeners, which fall back to the current behaviour.
 - **No API or CRD change.**
 - **Reconciliation takes longer** for connectivity-affecting changes, because per-broker resource reconciliation (and waiting for an asynchronously-assigned address) is interleaved with the roll.
   This is most pronounced for `loadbalancer`, where each per-broker LB is provisioned by the cloud (often minutes) and is now serialized across the roll; for large clusters (200+ brokers) the total can be very large.
   Per-broker waits are bounded by `operationTimeoutMs`, but the overall reconcile may approach or exceed the reconciliation interval, so overlap and lock behaviour and progress logging must be considered.
-  The migration is resumable (per-broker convergence guard), so an aborted reconcile continues on the next pass rather than restarting from scratch.
-- **Listener status** is fully populated only after the roll completes; intermediate reconcile passes may report a mix of old and new per-broker addresses, all valid at the time.
+  The migration is resumable: an aborted reconcile continues with the not-yet-converged brokers on the next pass, the same way the operator already resumes any interrupted roll.
 
 ## Rejected alternatives
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository lists proposals for the Strimzi project. A template for new prop
 
 | #  | Title                                                                 |
 |:--:|:----------------------------------------------------------------------|
+| 148 | [Safe rollout of listener connectivity changes](./148-safe-listener-connectivity-rollout.md) |
 | 144 | [Strimzi _Gatekeeper_ plugin system](./144-Strimzi-Gatekeeper-plugin-system.md) |
 | 143 | [Enable SSL for Metrics Reporter](./143-enable-ssl-for-metrics-reporter.md) |
 | 142 | [Per-broker annotation and label templates for Kafka listeners](./142-per-broker-annotation-and-label-templates.md) |


### PR DESCRIPTION
### Type of Change

- New Proposal

### Description

Proposal 148: make connectivity-affecting listener changes (type change, port change, adding or removing a listener) safe to roll out and roll back, for all listener types that provision per-broker Kubernetes resources (`nodeport`, `loadbalancer`, `cluster-ip`, `route`, `ingress`).

Today `KafkaReconciler` reconciles every per-broker listener resource up front (`listeners()`) and then rolls the pods one at a time. That leaves a window where a not-yet-rolled broker's `Service`/`Route`/`Ingress` already points at a listener the broker is not yet serving, so clients fail for the whole roll. On `nodeport`, a type-change rollback also re-allocates random node ports, which can move a port onto a different listener and cause SASL-mechanism mismatches that do not self-heal.

The proposal reconciles each broker's listener resources in lockstep with that broker's own restart, so each broker's resources always match the listener it is serving. It covers the `KafkaRoller` hook point, a per-broker convergence guard for idempotency/resumability, bootstrap-last handling, the internal-listener precondition, the KRaft-only correctness argument, an implementation sketch, a feature gate, testing, and rejected alternatives.

AI assistance was used to help structure and edit this proposal; the problem, design, trade-offs, and reasoning are my own (the work comes from a real listener-rollout incident).

### Checklist

- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
- [x] BEFORE MERGING: The next free sequence number was used for the proposal and all its assets (images, etc.)
- [x] BEFORE MERGING: The proposal index in README.md was updated