### PR TITLE
Add proposal for Kafka Exporter re-implementation within Strimzi org

### DIFF
--- a/157-kafka-exporter-re-implementation.md
+++ b/157-kafka-exporter-re-implementation.md
@@ -25,14 +25,29 @@ We will create new repository under Strimzi organization - `strimzi/kafka-export
 ### Implementation
 
 Because Strimzi mostly consists of Java projects, the proposal is to implement the tool in Java.
-The implementation will use the minimal required dependencies and will contain all the existing features of the latest version of Kafka Exporter.
+The implementation will use the minimal required dependencies and will cover all functionality currently used by Strimzi.
+Features not used by Strimzi are explicitly out of scope for the initial implementation, including Helm charts, Kerberos authentication, and SASL mechanisms other than OAUTHBEARER.
 
 All the metrics that the tool will export will follow the same naming as the existing Kafka Exporter, but this can change in the future based on community feedback and needs.
 
 To keep the minimal dependency tree we will use the following:
 - `kafka-clients` for `AdminClient`
 - `prometheus-metrics-core` and `prometheus-metrics-exposition-formats` for Prometheus endpoint
-- JDK built-in http server for `/metrics` and `/healthz/ready` endpoints
+- JDK built-in HTTP server for the `/metrics` and health check endpoints
+
+#### HTTP Server
+
+The tool exposes two HTTP listeners on separate ports, following the same pattern used by the Kafka Bridge:
+
+- **Management port** (default: `9404`) — serves `/healthz/ready` over plain HTTP only.
+This port is never TLS-enabled and is used exclusively by the operator's liveness and readiness probes.
+Keeping health check endpoints on a dedicated plain-HTTP port means probe behaviour is stable regardless of the TLS configuration of the metrics endpoint.
+- **Metrics port** (default: `9403`) — serves `/metrics`.
+In the initial release this port also uses plain HTTP.
+
+Adding TLS support to the metrics port is tracked in [strimzi-kafka-operator#12556](https://github.com/strimzi/strimzi-kafka-operator/issues/12556) and is planned as a follow-up.
+When implemented, it will follow the same CRD pattern used by Kafka Bridge's `spec.http.tls` — a `tls` block under `spec.kafkaExporter` containing a `certificateAndKey` reference and an optional `trustedCertificates` list for mTLS.
+The two-port architecture ensures that enabling TLS on the metrics port will not require any changes to the probe configuration in the operator.
 
 ### CI/CD
 
@@ -42,8 +57,40 @@ As an output of the build and release process, we will produce a tarball with a 
 ### Versioning
 
 The tool will follow Strimzi versioning `<major>.<minor>.<micro>` as other projects do.
-The first version will be `0.1.0`, even though the tool already covers all existing Kafka Exporter functionality.
-We will keep the tool in the 0.x line for one or two releases to gather feedback and confirm parity with the Go implementation in production before releasing the `1.0.0`.
+The first version will be `0.1.0`, even though the tool already covers all Strimzi-required functionality.
+We will keep the tool in the 0.x line for two releases to gather feedback and validate the implementation covers all Strimzi use cases in production before releasing the `1.0.0`.
+
+### Strimzi Kafka Operator changes
+
+#### Feature Gate for Strimzi Kafka Operator
+
+The switch from the Go binary to the Java implementation will be gated behind a new feature gate — `KafkaExporterJavaImplementation` — to allow a safe, opt-in transition for users.
+
+The gate will progress through the standard Strimzi feature gate lifecycle:
+
+1. Introduced as **alpha** (disabled by default) - users can opt in to the new Java implementation while the Go binary remains the default.
+2. Promoted to **beta** (enabled by default) after two releases (in 1.4.0) once sufficient feedback and production validation has been gathered - users can still opt out by explicitly disabling the gate.
+3. Promoted to **GA** and the feature gate removed after four releases (in 1.6.0) - the Go binary is dropped and the Java implementation becomes the only option.
+
+When the feature gate is disabled, the operator continues to use the existing Go binary and `kafka_exporter_run.sh` launch script unchanged.
+When the feature gate is enabled, the operator copies the fat-jar artifact from the `strimzi/kafka-exporter` repository into the Kafka image and uses an updated launch script to start the Java implementation.
+
+#### CRD and API Changes
+
+Moving from a Go binary to a Java implementation requires normalising some fields in `KafkaExporterSpec` that are Go-specific.
+
+The following changes will be made to the `kafkaExporter` section of the Kafka CR:
+
+- `logging` — currently accepts Go-style log levels (`info`, `debug`, `trace`).
+  The existing field is kept and its value is mapped internally to the equivalent Java log level, so existing CRs continue to work without changes.
+- `enableSaramaLogging` — this field controls logging of the Sarama Go client library, which has no equivalent in the Java implementation.
+  The field will be deprecated and ignored when the Java implementation is active.
+  When the feature gate is enabled and this field is set, the operator will emit a warning in its log.
+- `jvmOptions` — a new field following the standard Strimzi `JvmOptions` type will be added to allow users to configure JVM heap, GC options, and other JVM flags, consistent with how other Java-based Strimzi components expose this.
+  This field is only meaningful when the Java implementation is active.
+  When the feature gate is disabled and this field is set, the operator will emit a warning in its log that `jvmOptions` is ignored by the Go binary.
+
+The deprecated Go-specific fields will be removed in a future API version once the feature gate reaches GA and the Go binary is fully retired.
 
 ### Documentation
 
@@ -52,27 +99,24 @@ The Strimzi documentation will be updated to reflect the switch from the upstrea
 
 ### Testing
 
-The new repository will include unit tests covering the metrics collection and registry logic, and integration tests running against a real Kafka instance.
+The new repository will include unit tests covering the metrics collection and registry logic, and integration tests running against a real Kafka instance using `strimzi-test-container`.
 Existing system tests in `strimzi-kafka-operator` will ensure that new implementation of Kafka Exporter continues to work end-to-end after the swap.
 No additional e2e scenarios will be needed.
 
 ### Security
 
-The new implementation will keep the same TLS and SASL/OAuth handling that Kafka Exporter has today, so the Kafka Exporter container keeps the same permissions and credential sources it already has, mounted certificates and Secrets provided by the Strimzi operator.
+The new implementation preserves the TLS/mTLS configuration used by Strimzi today. 
+The tool continues to use the cluster CA certificate and client certificate/key mounted by the operator via Secrets.
 No credentials will be logged or persisted by the tool itself.
-Moving to a Java implementation removes the current need to trust and verify pre-built third-party Go binaries and their checksums, replacing them with well known JVM dependencies that already go through Strimzi's existing CVE scanning and patching process.
-The AdminClient will only need the same read-level Kafka permissions the current tool requires today, describing topics and consumer groups, so no privilege changes are introduced.
+Moving to a Java implementation removes the current need to trust and verify pre-built third-party Go binaries and their checksums, replacing them with well-known JVM dependencies that already go through Strimzi's existing CVE scanning and patching process.
 
-Any security improvements will be added once we will create repo with initial implementation.
+SASL OAUTHBEARER support will be added as a follow-up when required by Cluster Security.
+Other SASL mechanisms are out of scope and will not be implemented.
 
 ## Affected Projects
 
 This proposal affects only `strimzi-kafka-operator` repo.
 Other sub-projects are not affected.
-
-In the operator repository, we will need to change the make targets to copy the new artifacts from the `strimzi/kafka-exporter` repository into the Kafka image.
-The existing `kafka_exporter_run.sh` script will be enhanced to launch the fat-jar instead of the Go binary with all necessary configs.
-The possibilities to configure Kafka Exporter through Kafka CR will remain the same as today.
 
 ## Backwards Compatibility
 
@@ -96,4 +140,4 @@ Kafka Exporter is a small tool and Go is great for such tools, however, we do no
 
 Quarkus provides an easy way to write small tools that expose Prometheus metrics.
 However, it also brings additional dependencies that can be easily avoided with pure Java.
-The main advantage of Quarkus for a tool like this would be native image builds, but since Strimzi images uses the JVM, there is no benefit in native images now.
+The main advantage of Quarkus for a tool like this would be native image builds, but native images are not viable for Strimzi because they only support x86-64 and aarch64, while Strimzi ships images for s390x and ppc64le as well.

--- a/157-kafka-exporter-re-implementation.md
+++ b/157-kafka-exporter-re-implementation.md
@@ -20,7 +20,7 @@ Currently, there is 215 open issues and 58 open pull requests from the community
 
 To mitigate security problems and allow us to better maintain the tool and provide new features, we should re-implement Kafka Exporter tool.
 
-We will create new repository under Strimzi organization - `strimzi/kafka-exporter` - that will contain the implementation code.
+We will create new repository under Strimzi organization - `strimzi/lag-reporter` - that will contain the implementation code.
 
 ### Implementation
 
@@ -39,41 +39,39 @@ To keep the minimal dependency tree we will use the following:
 
 The tool exposes two HTTP listeners on separate ports, following the same pattern used by the Kafka Bridge:
 
-- **Management port** (default: `9404`) — serves `/healthz/ready` over plain HTTP only.
+- **Management port** (default: `8080`) — serves `/healthz/ready` over plain HTTP only.
 This port is never TLS-enabled and is used exclusively by the operator's liveness and readiness probes.
 Keeping health check endpoints on a dedicated plain-HTTP port means probe behaviour is stable regardless of the TLS configuration of the metrics endpoint.
-- **Metrics port** (default: `9403`) — serves `/metrics`.
+- **Metrics port** (default: `9404`) — serves `/metrics`.
 In the initial release this port also uses plain HTTP.
 
-Adding TLS support to the metrics port is tracked in [strimzi-kafka-operator#12556](https://github.com/strimzi/strimzi-kafka-operator/issues/12556) and is planned as a follow-up.
-When implemented, it will follow the same CRD pattern used by Kafka Bridge's `spec.http.tls` — a `tls` block under `spec.kafkaExporter` containing a `certificateAndKey` reference and an optional `trustedCertificates` list for mTLS.
-The two-port architecture ensures that enabling TLS on the metrics port will not require any changes to the probe configuration in the operator.
+There is community demand for having TLS enabled on metrics endpoint ([strimzi-kafka-operator#12556](https://github.com/strimzi/strimzi-kafka-operator/issues/12556)).
+The implementation and integration into Strimzi Kafka Operator will require new proposal as it will need API changes for the tool.
 
 ### CI/CD
 
 The tool will follow Strimzi standards and will adopt the same CI/CD workflow we use for other projects.
-As an output of the build and release process, we will produce a tarball with a fat-jar that can be used in Strimzi images or in standalone distributions connected to Kafka.
+As an output of the build and release process, we will produce a zip file that we use across Strimzi org and that can be used in Strimzi images or in standalone distributions connected to Kafka.
 
 ### Versioning
 
 The tool will follow Strimzi versioning `<major>.<minor>.<micro>` as other projects do.
 The first version will be `0.1.0`, even though the tool already covers all Strimzi-required functionality.
-We will keep the tool in the 0.x line for two releases to gather feedback and validate the implementation covers all Strimzi use cases in production before releasing the `1.0.0`.
 
 ### Strimzi Kafka Operator changes
 
 #### Feature Gate for Strimzi Kafka Operator
 
-The switch from the Go binary to the Java implementation will be gated behind a new feature gate — `KafkaExporterJavaImplementation` — to allow a safe, opt-in transition for users.
+The switch from the Go binary to the Java implementation will be gated behind a new feature gate — `StrimziLagReporter` — to allow a safe, opt-in transition for users.
 
 The gate will progress through the standard Strimzi feature gate lifecycle:
 
-1. Introduced as **alpha** (disabled by default) - users can opt in to the new Java implementation while the Go binary remains the default.
-2. Promoted to **beta** (enabled by default) after two releases (in 1.4.0) once sufficient feedback and production validation has been gathered - users can still opt out by explicitly disabling the gate.
-3. Promoted to **GA** and the feature gate removed after four releases (in 1.6.0) - the Go binary is dropped and the Java implementation becomes the only option.
+1. Introduced as **alpha** (disabled by default) - users can opt in to the new Java implementation while the Go binary remains the default (introduced in 1.4.0).
+2. Promoted to **beta** (enabled by default) after two releases (in 1.6.0) once sufficient feedback and production validation has been gathered - users can still opt out by explicitly disabling the gate.
+3. Promoted to **GA** and the feature gate removed after four releases (in 1.8.0) - the Go binary is dropped and the Java implementation becomes the only option.
 
 When the feature gate is disabled, the operator continues to use the existing Go binary and `kafka_exporter_run.sh` launch script unchanged.
-When the feature gate is enabled, the operator copies the fat-jar artifact from the `strimzi/kafka-exporter` repository into the Kafka image and uses an updated launch script to start the Java implementation.
+When the feature gate is enabled, the operator will use Java binary baked in the Kafka image and `lag_reporter_run.sh` to launch the application.
 
 #### CRD and API Changes
 
@@ -94,13 +92,13 @@ The deprecated Go-specific fields will be removed in a future API version once t
 
 ### Documentation
 
-The `strimzi/kafka-exporter` repository will include a README covering all configuration options, the full list of exported metrics, and instructions for running the tool standalone.
+The `strimzi/lag-reporter` repository will include a README covering all configuration options, the full list of exported metrics, and instructions for running the tool standalone.
 The Strimzi documentation will be updated to reflect the switch from the upstream Go binary to the new Java implementation.
 
 ### Testing
 
 The new repository will include unit tests covering the metrics collection and registry logic, and integration tests running against a real Kafka instance using `strimzi-test-container`.
-Existing system tests in `strimzi-kafka-operator` will ensure that new implementation of Kafka Exporter continues to work end-to-end after the swap.
+Existing system tests in `strimzi-kafka-operator` will ensure that implementation of Lag Reporter continues to work end-to-end after the swap.
 No additional e2e scenarios will be needed.
 
 ### Security
@@ -110,8 +108,8 @@ The tool continues to use the cluster CA certificate and client certificate/key 
 No credentials will be logged or persisted by the tool itself.
 Moving to a Java implementation removes the current need to trust and verify pre-built third-party Go binaries and their checksums, replacing them with well-known JVM dependencies that already go through Strimzi's existing CVE scanning and patching process.
 
-SASL OAUTHBEARER support will be added as a follow-up when required by Cluster Security.
-Other SASL mechanisms are out of scope and will not be implemented.
+SASL OAUTHBEARER support will be added as a follow-up.
+Other SASL mechanisms are currently out of scope.
 
 ## Affected Projects
 

--- a/157-kafka-exporter-re-implementation.md
+++ b/157-kafka-exporter-re-implementation.md
@@ -14,6 +14,7 @@ The latest release, v1.10.0, was published on 2026-09-08 after a period of minim
 This opens space for potential security issues as CVEs may not be fixed promptly.
 
 This situation is also not helpful for new features that we would like to add into the exporter.
+Additionally, the upstream project relies on a third-party Go Kafka client rather than the official Apache Kafka client, meaning it does not benefit from the same level of support and compatibility guarantees that the official client provides.
 
 ## Proposal
 
@@ -33,6 +34,17 @@ To keep the minimal dependency tree we will use the following:
 - `kafka-clients` for `AdminClient`
 - `prometheus-metrics-core` and `prometheus-metrics-exposition-formats` for Prometheus endpoint
 - JDK built-in HTTP server for the `/metrics` and health check endpoints
+
+#### Collection Model
+
+Metrics collection is decoupled from the Prometheus scrape.
+A background scheduler runs a collection cycle on a configurable interval (default 30 seconds).
+Each cycle executes a sequence of batched `AdminClient` calls — cluster description, topic listing and description, offset fetching, consumer group listing, group description, and committed offset fetching — and assembles the results into an immutable snapshot.
+The snapshot is atomically swapped into the metrics registry.
+The `/metrics` endpoint only reads the latest snapshot; no Kafka calls happen in the scrape path and HTTP responses are always fast regardless of cluster size.
+
+On collection failure the previous snapshot continues to be served and the readiness probe reflects the unhealthy state.
+This avoids the `up == 0` failure mode seen in the upstream `kafka_exporter`, where scrapes time out under cluster load and dashboards go blind exactly when the cluster is most stressed.
 
 #### HTTP Server
 
@@ -79,7 +91,6 @@ The section will include the following fields from the start:
 - `groupExcludeRegex` — consumer group exclude regex.
 - `topicRegex` — topic include regex (default: `.*`).
 - `topicExcludeRegex` — topic exclude regex.
-- `showAllOffsets` — whether to report offsets for all partitions the group has ever committed to (default: `true`).
 - `logging` — standard Strimzi `Logging` type (Log4j 2), replacing the plain string `logging` field from `kafkaExporter`.
 - `jvmOptions` — standard Strimzi `JvmOptions` type for JVM heap, GC options, and flags.
 - `resources` — CPU and memory resource requirements.
@@ -110,14 +121,16 @@ The tool continues to use the cluster CA certificate and client certificate/key 
 No credentials will be logged or persisted by the tool itself.
 Moving to a Java implementation removes the current need to trust and verify pre-built third-party Go binaries and their checksums, replacing them with well-known JVM dependencies that already go through Strimzi's existing CVE scanning and patching process.
 
-SASL OAUTHBEARER support will be added as a near-term follow-up.
+SASL OAUTHBEARER support will be part of initial implementation.
 It is required for Strimzi Cluster Security and is straightforward to implement by including Strimzi OAuth as a dependency and adding the relevant Kafka client configuration.
 Other SASL mechanisms are currently out of scope.
 
 ## Affected Projects
 
-This proposal affects only `strimzi-kafka-operator` repo.
-Other sub-projects are not affected.
+This proposal affects the following projects:
+
+- `strimzi/insights-reporter` — new repository created by this proposal.
+- `strimzi-kafka-operator` — operator changes to introduce `spec.insightsReporter`, deprecate `spec.kafkaExporter`, and update system tests.
 
 ## Backwards Compatibility
 

--- a/157-kafka-exporter-re-implementation.md
+++ b/157-kafka-exporter-re-implementation.md
@@ -1,0 +1,99 @@
+# Kafka Exporter reimplementation
+
+This proposal suggests to re-implement Kafka Exporter tool under Strimzi organization in Java.
+
+## Current Situation
+
+Strimzi currently downloads binaries from released version of [kafka_exporter](https://github.com/danielqsj/kafka_exporter) tool on GitHub.
+The binaries are baked into Strimzi images and shipped as an optional tool for extending Kafka consumer metrics.
+
+## Motivation
+
+The project is widely used by Kafka community, however, it is not well maintained.
+Latest release is from 2025-02-17 which makes it almost year and half old.
+This opens space for potential security issues as there are CVEs that are not fixed.
+
+This situation is also not much helpful for new features that we would like to add into the exporter.
+Currently, there is 215 open issues and 58 open pull requests from the community with not much attention from the code owner.
+
+## Proposal
+
+To mitigate security problems and allow us to better maintain the tool and provide new features, we should re-implement Kafka Exporter tool.
+
+We will create new repository under Strimzi organization - `strimzi/kafka-exporter` - that will contain the implementation code.
+
+### Implementation
+
+Because Strimzi mostly consists of Java projects, the proposal is to implement the tool in Java.
+The implementation will use the minimal required dependencies and will contain all the existing features of the latest version of Kafka Exporter.
+
+All the metrics that the tool will export will follow the same naming as the existing Kafka Exporter, but this can change in the future based on community feedback and needs.
+
+To keep the minimal dependency tree we will use the following:
+- `kafka-clients` for `AdminClient`
+- `prometheus-metrics-core` and `prometheus-metrics-exposition-formats` for Prometheus endpoint
+- JDK built-in http server for `/metrics` and `/healthz/ready` endpoints
+
+### CI/CD
+
+The tool will follow Strimzi standards and will adopt the same CI/CD workflow we use for other projects.
+As an output of the build and release process, we will produce a tarball with a fat-jar that can be used in Strimzi images or in standalone distributions connected to Kafka.
+
+### Versioning
+
+The tool will follow Strimzi versioning `<major>.<minor>.<micro>` as other projects do.
+The first version will be `0.1.0`, even though the tool already covers all existing Kafka Exporter functionality.
+We will keep the tool in the 0.x line for one or two releases to gather feedback and confirm parity with the Go implementation in production before releasing the `1.0.0`.
+
+### Documentation
+
+The `strimzi/kafka-exporter` repository will include a README covering all configuration options, the full list of exported metrics, and instructions for running the tool standalone.
+The Strimzi documentation will be updated to reflect the switch from the upstream Go binary to the new Java implementation.
+
+### Testing
+
+The new repository will include unit tests covering the metrics collection and registry logic, and integration tests running against a real Kafka instance.
+Existing system tests in `strimzi-kafka-operator` will ensure that new implementation of Kafka Exporter continues to work end-to-end after the swap.
+No additional e2e scenarios will be needed.
+
+### Security
+
+The new implementation will keep the same TLS and SASL/OAuth handling that Kafka Exporter has today, so the Kafka Exporter container keeps the same permissions and credential sources it already has, mounted certificates and Secrets provided by the Strimzi operator.
+No credentials will be logged or persisted by the tool itself.
+Moving to a Java implementation removes the current need to trust and verify pre-built third-party Go binaries and their checksums, replacing them with well known JVM dependencies that already go through Strimzi's existing CVE scanning and patching process.
+The AdminClient will only need the same read-level Kafka permissions the current tool requires today, describing topics and consumer groups, so no privilege changes are introduced.
+
+Any security improvements will be added once we will create repo with initial implementation.
+
+## Affected Projects
+
+This proposal affects only `strimzi-kafka-operator` repo.
+Other sub-projects are not affected.
+
+In the operator repository, we will need to change the make targets to copy the new artifacts from the `strimzi/kafka-exporter` repository into the Kafka image.
+The existing `kafka_exporter_run.sh` script will be enhanced to launch the fat-jar instead of the Go binary with all necessary configs.
+The possibilities to configure Kafka Exporter through Kafka CR will remain the same as today.
+
+## Backwards Compatibility
+
+This proposal is fully compatible with previous versions as new implementation will export all the same metrics as the original implementation.
+The tool will also follow the same environment variables and parameters that are used for configuration of current Kafka Exporter.
+Breaking removals of configuration options will only be possible in upcoming releases.
+
+## Rejected Alternatives
+
+### Fork Kafka Exporter to Strimzi org
+
+We could simply fork the original Kafka Exporter and just fix CVEs.
+However, this would require onboarding it to our build mechanisms and removing things we don't want, such as Helm charts.
+These changes are straightforward, but we would still need to maintain Go code, which is not our team's expertise.
+
+### Re-write Kafka Exporter in Go
+
+Kafka Exporter is a small tool and Go is great for such tools, however, we do not have much experience across the maintainers team, and it might be hard to find an owner for it with proper experience.
+
+### Re-write Kafka Exporter in Quarkus
+
+Quarkus provides an easy way to write small tools that expose Prometheus metrics.
+However, it also brings additional dependencies that can be easily avoided with pure Java.
+The main advantage of Quarkus for a tool like this would be native image builds, but since Strimzi images uses the JVM, there is no benefit in native images now.

--- a/157-kafka-exporter-re-implementation.md
+++ b/157-kafka-exporter-re-implementation.md
@@ -46,6 +46,7 @@ In the initial release this port also uses plain HTTP.
 
 There is community demand for having TLS enabled on metrics endpoint ([strimzi-kafka-operator#12556](https://github.com/strimzi/strimzi-kafka-operator/issues/12556)).
 The implementation and integration of TLS configuration into Strimzi Kafka Operator will require a new proposal as it will need API changes for the tool.
+When TLS support is added, the implementation will use PEM files and Strimzi config providers, consistent with the approach used by other Strimzi components.
 
 ### CI/CD
 
@@ -65,7 +66,8 @@ Insights Reporter will be introduced as a new, parallel section in the Kafka CR 
 This allows users to opt in to the new Java implementation without any changes to their existing `kafkaExporter` configuration.
 
 The `spec.kafkaExporter` section will be set as **deprecated** from the moment `spec.insightsReporter` is introduced.
-The upstream `kafka_exporter` binary will be updated to v1.10.0 and continue to be supported and bundled in Strimzi images until new API version or until the tool will work without significant required changes on our side.
+The upstream `kafka_exporter` binary will be updated to v1.10.0 and continue to be supported and bundled in Strimzi images.
+We will keep to update Kafka Exporter until new API version or until the tool will work without significant required changes on our side.
 The `spec.kafkaExporter` section and the Go binary will be removed in a future API version once the deprecation period ends.
 
 The new `spec.insightsReporter` section follows the same conventions as other Strimzi components such as CruiseControl.
@@ -87,7 +89,9 @@ The section will include the following fields from the start:
 
 Fields that exist in `kafkaExporter` but are Go-specific, such as `enableSaramaLogging`, will not be carried over to `spec.insightsReporter`.
 
-When both `spec.kafkaExporter` and `spec.insightsReporter` are set, the operator will emit a warning and use `spec.insightsReporter`, ignoring `spec.kafkaExporter`.
+Both `spec.kafkaExporter` and `spec.insightsReporter` can be set at the same time.
+This allows users to run both implementations in parallel during migration — for example to compare metrics output or verify parity before switching over.
+When both are configured, the operator will deploy both components independently and emit a warning recommending migration to `spec.insightsReporter`.
 
 ### Documentation
 
@@ -101,12 +105,13 @@ Existing system tests in `strimzi-kafka-operator` will be extended to cover Insi
 
 ### Security
 
-The new implementation preserves the TLS/mTLS configuration used by Strimzi today.
-The tool continues to use the cluster CA certificate and client certificate/key mounted by the operator via Secrets.
+The new implementation preserves the TLS/mTLS configuration used by Strimzi today for connecting to Kafka.
+The tool continues to use the cluster CA certificate and client certificate/key mounted by the operator via Secrets, loaded via PEM files and Strimzi config providers.
 No credentials will be logged or persisted by the tool itself.
 Moving to a Java implementation removes the current need to trust and verify pre-built third-party Go binaries and their checksums, replacing them with well-known JVM dependencies that already go through Strimzi's existing CVE scanning and patching process.
 
-SASL OAUTHBEARER support will be added as a follow-up.
+SASL OAUTHBEARER support will be added as a near-term follow-up.
+It is required for Strimzi Cluster Security and is straightforward to implement by including Strimzi OAuth as a dependency and adding the relevant Kafka client configuration.
 Other SASL mechanisms are currently out of scope.
 
 ## Affected Projects

--- a/157-kafka-exporter-re-implementation.md
+++ b/157-kafka-exporter-re-implementation.md
@@ -10,17 +10,16 @@ The binaries are baked into Strimzi images and shipped as an optional tool for e
 ## Motivation
 
 The project is widely used by Kafka community, however, it is not well maintained.
-Latest release is from 2025-02-17 which makes it almost year and half old.
-This opens space for potential security issues as there are CVEs that are not fixed.
+The latest release, v1.10.0, was published on 2026-09-08 after a period of minimal activity, but the project still has 216 open issues and 56 open pull requests with limited attention from the code owner.
+This opens space for potential security issues as CVEs may not be fixed promptly.
 
-This situation is also not much helpful for new features that we would like to add into the exporter.
-Currently, there is 215 open issues and 58 open pull requests from the community with not much attention from the code owner.
+This situation is also not helpful for new features that we would like to add into the exporter.
 
 ## Proposal
 
 To mitigate security problems and allow us to better maintain the tool and provide new features, we should re-implement Kafka Exporter tool.
 
-We will create new repository under Strimzi organization - `strimzi/lag-reporter` - that will contain the implementation code.
+We will create new repository under Strimzi organization - `strimzi/insights-reporter` - that will contain the implementation code.
 
 ### Implementation
 
@@ -46,7 +45,7 @@ Keeping health check endpoints on a dedicated plain-HTTP port means probe behavi
 In the initial release this port also uses plain HTTP.
 
 There is community demand for having TLS enabled on metrics endpoint ([strimzi-kafka-operator#12556](https://github.com/strimzi/strimzi-kafka-operator/issues/12556)).
-The implementation and integration into Strimzi Kafka Operator will require new proposal as it will need API changes for the tool.
+The implementation and integration of TLS configuration into Strimzi Kafka Operator will require a new proposal as it will need API changes for the tool.
 
 ### CI/CD
 
@@ -60,50 +59,49 @@ The first version will be `0.1.0`, even though the tool already covers all Strim
 
 ### Strimzi Kafka Operator changes
 
-#### Feature Gate for Strimzi Kafka Operator
-
-The switch from the Go binary to the Java implementation will be gated behind a new feature gate — `StrimziLagReporter` — to allow a safe, opt-in transition for users.
-
-The gate will progress through the standard Strimzi feature gate lifecycle:
-
-1. Introduced as **alpha** (disabled by default) - users can opt in to the new Java implementation while the Go binary remains the default (introduced in 1.4.0).
-2. Promoted to **beta** (enabled by default) after two releases (in 1.6.0) once sufficient feedback and production validation has been gathered - users can still opt out by explicitly disabling the gate.
-3. Promoted to **GA** and the feature gate removed after four releases (in 1.8.0) - the Go binary is dropped and the Java implementation becomes the only option.
-
-When the feature gate is disabled, the operator continues to use the existing Go binary and `kafka_exporter_run.sh` launch script unchanged.
-When the feature gate is enabled, the operator will use Java binary baked in the Kafka image and `lag_reporter_run.sh` to launch the application.
-
 #### CRD and API Changes
 
-Moving from a Go binary to a Java implementation requires normalising some fields in `KafkaExporterSpec` that are Go-specific.
+Insights Reporter will be introduced as a new, parallel section in the Kafka CR — `spec.insightsReporter` — alongside the existing `spec.kafkaExporter` section.
+This allows users to opt in to the new Java implementation without any changes to their existing `kafkaExporter` configuration.
 
-The following changes will be made to the `kafkaExporter` section of the Kafka CR:
+The `spec.kafkaExporter` section will be set as **deprecated** from the moment `spec.insightsReporter` is introduced.
+The upstream `kafka_exporter` binary will be updated to v1.10.0 and continue to be supported and bundled in Strimzi images until new API version or until the tool will work without significant required changes on our side.
+The `spec.kafkaExporter` section and the Go binary will be removed in a future API version once the deprecation period ends.
 
-- `logging` — currently accepts Go-style log levels (`info`, `debug`, `trace`).
-  The existing field is kept and its value is mapped internally to the equivalent Java log level, so existing CRs continue to work without changes.
-- `enableSaramaLogging` — this field controls logging of the Sarama Go client library, which has no equivalent in the Java implementation.
-  The field will be deprecated and ignored when the Java implementation is active.
-  When the feature gate is enabled and this field is set, the operator will emit a warning in its log.
-- `jvmOptions` — a new field following the standard Strimzi `JvmOptions` type will be added to allow users to configure JVM heap, GC options, and other JVM flags, consistent with how other Java-based Strimzi components expose this.
-  This field is only meaningful when the Java implementation is active.
-  When the feature gate is disabled and this field is set, the operator will emit a warning in its log that `jvmOptions` is ignored by the Go binary.
+The new `spec.insightsReporter` section follows the same conventions as other Strimzi components such as CruiseControl.
+The component is enabled by including the section in the CR and disabled by omitting it — there is no separate `enabled` field, consistent with `spec.kafkaExporter` and `spec.cruiseControl`.
+The section will include the following fields from the start:
 
-The deprecated Go-specific fields will be removed in a future API version once the feature gate reaches GA and the Go binary is fully retired.
+- `image` — container image override.
+- `groupRegex` — consumer group include regex (default: `.*`).
+- `groupExcludeRegex` — consumer group exclude regex.
+- `topicRegex` — topic include regex (default: `.*`).
+- `topicExcludeRegex` — topic exclude regex.
+- `showAllOffsets` — whether to report offsets for all partitions the group has ever committed to (default: `true`).
+- `logging` — standard Strimzi `Logging` type (Log4j 2), replacing the plain string `logging` field from `kafkaExporter`.
+- `jvmOptions` — standard Strimzi `JvmOptions` type for JVM heap, GC options, and flags.
+- `resources` — CPU and memory resource requirements.
+- `livenessProbe` — liveness probe configuration.
+- `readinessProbe` — readiness probe configuration.
+- `template` — pod and container template overrides.
+
+Fields that exist in `kafkaExporter` but are Go-specific, such as `enableSaramaLogging`, will not be carried over to `spec.insightsReporter`.
+
+When both `spec.kafkaExporter` and `spec.insightsReporter` are set, the operator will emit a warning and use `spec.insightsReporter`, ignoring `spec.kafkaExporter`.
 
 ### Documentation
 
-The `strimzi/lag-reporter` repository will include a README covering all configuration options, the full list of exported metrics, and instructions for running the tool standalone.
-The Strimzi documentation will be updated to reflect the switch from the upstream Go binary to the new Java implementation.
+The `strimzi/insights-reporter` repository will include a README covering all configuration options, the full list of exported metrics, and instructions for running the tool standalone.
+The Strimzi documentation will be updated to reflect the new component and the deprecation of `spec.kafkaExporter`.
 
 ### Testing
 
 The new repository will include unit tests covering the metrics collection and registry logic, and integration tests running against a real Kafka instance using `strimzi-test-container`.
-Existing system tests in `strimzi-kafka-operator` will ensure that implementation of Lag Reporter continues to work end-to-end after the swap.
-No additional e2e scenarios will be needed.
+Existing system tests in `strimzi-kafka-operator` will be extended to cover Insights Reporter and will continue to cover the existing Kafka Exporter for the duration of the deprecation period.
 
 ### Security
 
-The new implementation preserves the TLS/mTLS configuration used by Strimzi today. 
+The new implementation preserves the TLS/mTLS configuration used by Strimzi today.
 The tool continues to use the cluster CA certificate and client certificate/key mounted by the operator via Secrets.
 No credentials will be logged or persisted by the tool itself.
 Moving to a Java implementation removes the current need to trust and verify pre-built third-party Go binaries and their checksums, replacing them with well-known JVM dependencies that already go through Strimzi's existing CVE scanning and patching process.
@@ -118,11 +116,17 @@ Other sub-projects are not affected.
 
 ## Backwards Compatibility
 
-This proposal is fully compatible with previous versions as new implementation will export all the same metrics as the original implementation.
-The tool will also follow the same environment variables and parameters that are used for configuration of current Kafka Exporter.
-Breaking removals of configuration options will only be possible in upcoming releases.
+Users who continue to use `spec.kafkaExporter` are not affected.
+The Go binary is kept at the latest upstream release (v1.10.0) and will continue to function until the deprecation period ends.
+Users who migrate to `spec.insightsReporter` will get the same metric names as today, so existing dashboards and alerting rules continue to work without modification.
 
 ## Rejected Alternatives
+
+### Feature gate transition
+
+An earlier version of this proposal used a feature gate to switch between the Go binary and the Java implementation within the existing `spec.kafkaExporter` API.
+This was rejected because it couples two unrelated implementations under the same API, complicates the operator logic for the duration of the gate lifecycle, and prevents a clean API that reflects the capabilities of the Java implementation.
+Introducing a new `spec.insightsReporter` section alongside a deprecated `spec.kafkaExporter` is a cleaner separation.
 
 ### Fork Kafka Exporter to Strimzi org
 


### PR DESCRIPTION
### Type of Change

- New Proposal

### Description

This PR proposes new implementation of Kafka Exporter tool within Strimzi org in Java.

There is existing PoC - https://github.com/Frawless/franz-spediter/tree/pure-java (note that I didn't update the readme  from original Quarkus implementation that is in `quarkus` branch).

TODO - add links for Strimzi images with new KE

### Checklist

- [x] AI assistance was used to create this PR (see the [Strimzi AI policy](https://github.com/strimzi/governance/blob/main/AI_POLICY.md))
- [x] The proposal uses Markdown format with one sentence per line
- [ ] BEFORE MERGING: The next free sequence number was used for the proposal and all its assets (images, etc.)
- [ ] BEFORE MERGING: The proposal index in README.md was updated
